### PR TITLE
Mem free improvements

### DIFF
--- a/mbed-coap/sn_coap_protocol.h
+++ b/mbed-coap/sn_coap_protocol.h
@@ -38,7 +38,8 @@ extern "C" {
  *
  * \param *used_malloc_func_ptr is function pointer for used memory allocation function.
  *
- * \param *used_free_func_ptr is function pointer for used memory free function.
+ * \param *used_free_func_ptr is function pointer for used memory free function. Note: the implementation
+ *          must handle NULL parameter and ignore it just as typical libc's free() does.
  *
  * \param *used_tx_callback_ptr function callback pointer to tx function for sending coap messages
  *

--- a/source/include/sn_coap_header_internal.h
+++ b/source/include/sn_coap_header_internal.h
@@ -58,7 +58,7 @@ extern "C" {
  * \brief This structure is returned by sn_coap_exec() for sending
  */
 typedef struct sn_nsdl_transmit_ {
-    sn_nsdl_addr_s         *dst_addr_ptr;
+    sn_nsdl_addr_s          dst_addr_ptr;
 
     sn_nsdl_capab_e         protocol;
 

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -143,7 +143,7 @@ typedef struct coap_send_msg_ {
     uint8_t             resending_counter;  /* Tells how many times message is still tried to resend */
     uint32_t            resending_time;     /* Tells next resending time */
 
-    sn_nsdl_transmit_s *send_msg_ptr;
+    sn_nsdl_transmit_s  send_msg_ptr;
 
     struct coap_s       *coap;              /* CoAP library handle */
     void                *param;             /* Extra parameter that will be passed to TX/RX callback functions */

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -151,38 +151,17 @@ void sn_coap_parser_release_allocated_coap_msg_mem(struct coap_s *handle, sn_coa
     }
 
     if (freed_coap_msg_ptr != NULL) {
-        if (freed_coap_msg_ptr->uri_path_ptr != NULL) {
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->uri_path_ptr);
-        }
+        handle->sn_coap_protocol_free(freed_coap_msg_ptr->uri_path_ptr);
 
-        if (freed_coap_msg_ptr->token_ptr != NULL) {
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->token_ptr);
-        }
+        handle->sn_coap_protocol_free(freed_coap_msg_ptr->token_ptr);
 
         if (freed_coap_msg_ptr->options_list_ptr != NULL) {
-            if (freed_coap_msg_ptr->options_list_ptr->proxy_uri_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->proxy_uri_ptr);
-            }
-
-            if (freed_coap_msg_ptr->options_list_ptr->etag_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->etag_ptr);
-            }
-
-            if (freed_coap_msg_ptr->options_list_ptr->uri_host_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_host_ptr);
-            }
-
-            if (freed_coap_msg_ptr->options_list_ptr->location_path_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_path_ptr);
-            }
-
-            if (freed_coap_msg_ptr->options_list_ptr->location_query_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_query_ptr);
-            }
-
-            if (freed_coap_msg_ptr->options_list_ptr->uri_query_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_query_ptr);
-            }
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->proxy_uri_ptr);
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->etag_ptr);
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_host_ptr);
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_path_ptr);
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_query_ptr);
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_query_ptr);
 
             handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr);
         }

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -291,18 +291,15 @@ void sn_coap_protocol_clear_retransmission_buffer(struct coap_s *handle)
         return;
     }
     ns_list_foreach_safe(coap_send_msg_s, tmp, &handle->linked_list_resent_msgs) {
-        if (tmp->send_msg_ptr) {
-            if (tmp->send_msg_ptr->dst_addr_ptr) {
-                handle->sn_coap_protocol_free(tmp->send_msg_ptr->dst_addr_ptr->addr_ptr);
+        if (tmp->send_msg_ptr.dst_addr_ptr) {
+            handle->sn_coap_protocol_free(tmp->send_msg_ptr.dst_addr_ptr->addr_ptr);
 
-                handle->sn_coap_protocol_free(tmp->send_msg_ptr->dst_addr_ptr);
-            }
-            handle->sn_coap_protocol_free(tmp->send_msg_ptr->packet_ptr);
-
-            handle->sn_coap_protocol_free(tmp->send_msg_ptr->uri_path_ptr);
-
-            handle->sn_coap_protocol_free(tmp->send_msg_ptr);
+            handle->sn_coap_protocol_free(tmp->send_msg_ptr.dst_addr_ptr);
         }
+        handle->sn_coap_protocol_free(tmp->send_msg_ptr.packet_ptr);
+
+        handle->sn_coap_protocol_free(tmp->send_msg_ptr.uri_path_ptr);
+
         ns_list_remove(&handle->linked_list_resent_msgs, tmp);
         --handle->count_resent_msgs;
         handle->sn_coap_protocol_free(tmp);
@@ -318,9 +315,9 @@ int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint16_t ms
         return -1;
     }
     ns_list_foreach_safe(coap_send_msg_s, tmp, &handle->linked_list_resent_msgs) {
-        if (tmp->send_msg_ptr && tmp->send_msg_ptr->packet_ptr ) {
-            uint16_t temp_msg_id = (tmp->send_msg_ptr->packet_ptr[2] << 8);
-            temp_msg_id += (uint16_t)tmp->send_msg_ptr->packet_ptr[3];
+        if (tmp->send_msg_ptr.packet_ptr ) {
+            uint16_t temp_msg_id = (tmp->send_msg_ptr.packet_ptr[2] << 8);
+            temp_msg_id += (uint16_t)tmp->send_msg_ptr.packet_ptr[3];
             if(temp_msg_id == msg_id){
                 ns_list_remove(&handle->linked_list_resent_msgs, tmp);
                 --handle->count_resent_msgs;
@@ -737,29 +734,29 @@ int8_t sn_coap_protocol_exec(struct coap_s *handle, uint32_t current_time)
                     coap_version_e coap_version = COAP_VERSION_UNKNOWN;
 
                     /* Get message ID from stored sending message */
-                    uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr->packet_ptr[2] << 8);
-                    temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr->packet_ptr[3];
+                    uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
+                    temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
 
                     /* If RX callback have been defined.. */
                     if (stored_msg_ptr->coap->sn_coap_rx_callback != 0) {
                         sn_coap_hdr_s *tmp_coap_hdr_ptr;
                         /* Parse CoAP message, set status and call RX callback */
-                        tmp_coap_hdr_ptr = sn_coap_parser(stored_msg_ptr->coap, stored_msg_ptr->send_msg_ptr->packet_len, stored_msg_ptr->send_msg_ptr->packet_ptr, &coap_version);
+                        tmp_coap_hdr_ptr = sn_coap_parser(stored_msg_ptr->coap, stored_msg_ptr->send_msg_ptr.packet_len, stored_msg_ptr->send_msg_ptr.packet_ptr, &coap_version);
 
                         if (tmp_coap_hdr_ptr != 0) {
                             tmp_coap_hdr_ptr->coap_status = COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED;
 
-                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, stored_msg_ptr->send_msg_ptr->dst_addr_ptr, stored_msg_ptr->param);
+                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                             sn_coap_parser_release_allocated_coap_msg_mem(stored_msg_ptr->coap, tmp_coap_hdr_ptr);
                         }
                     }
                     /* Remove message from Linked list */
-                    sn_coap_protocol_linked_list_send_msg_remove(handle, stored_msg_ptr->send_msg_ptr->dst_addr_ptr, temp_msg_id);
+                    sn_coap_protocol_linked_list_send_msg_remove(handle, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, temp_msg_id);
                 } else {
                     /* Send message  */
-                    stored_msg_ptr->coap->sn_coap_tx_callback(stored_msg_ptr->send_msg_ptr->packet_ptr,
-                            stored_msg_ptr->send_msg_ptr->packet_len, stored_msg_ptr->send_msg_ptr->dst_addr_ptr, stored_msg_ptr->param);
+                    stored_msg_ptr->coap->sn_coap_tx_callback(stored_msg_ptr->send_msg_ptr.packet_ptr,
+                            stored_msg_ptr->send_msg_ptr.packet_len, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                     /* * * Count new Resending time  * * */
                     stored_msg_ptr->resending_time = current_time + (((uint32_t)(handle->sn_coap_resending_intervall * RESPONSE_RANDOM_FACTOR)) <<
@@ -827,26 +824,26 @@ static void sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, s
     stored_msg_ptr->resending_time = sending_time;
 
     /* Filling of sn_nsdl_transmit_s */
-    stored_msg_ptr->send_msg_ptr->protocol = SN_NSDL_PROTOCOL_COAP;
-    stored_msg_ptr->send_msg_ptr->packet_len = send_packet_data_len;
-    memcpy(stored_msg_ptr->send_msg_ptr->packet_ptr, send_packet_data_ptr, send_packet_data_len);
+    stored_msg_ptr->send_msg_ptr.protocol = SN_NSDL_PROTOCOL_COAP;
+    stored_msg_ptr->send_msg_ptr.packet_len = send_packet_data_len;
+    memcpy(stored_msg_ptr->send_msg_ptr.packet_ptr, send_packet_data_ptr, send_packet_data_len);
 
     /* Filling of sn_nsdl_addr_s */
-    stored_msg_ptr->send_msg_ptr->dst_addr_ptr->type = dst_addr_ptr->type;
-    stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_len = dst_addr_ptr->addr_len;
-    memcpy(stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
-    stored_msg_ptr->send_msg_ptr->dst_addr_ptr->port = dst_addr_ptr->port;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->type = dst_addr_ptr->type;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_len = dst_addr_ptr->addr_len;
+    memcpy(stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port = dst_addr_ptr->port;
 
     stored_msg_ptr->coap = handle;
     stored_msg_ptr->param = param;
 
     if (uri_path_len) {
-        stored_msg_ptr->send_msg_ptr->uri_path_ptr = handle->sn_coap_protocol_malloc(uri_path_len);
-        if (stored_msg_ptr->send_msg_ptr->uri_path_ptr == NULL){
+        stored_msg_ptr->send_msg_ptr.uri_path_ptr = handle->sn_coap_protocol_malloc(uri_path_len);
+        if (stored_msg_ptr->send_msg_ptr.uri_path_ptr == NULL){
             return;
         }
-        stored_msg_ptr->send_msg_ptr->uri_path_len = uri_path_len;
-        memcpy(stored_msg_ptr->send_msg_ptr->uri_path_ptr, uri_path_ptr, uri_path_len);
+        stored_msg_ptr->send_msg_ptr.uri_path_len = uri_path_len;
+        memcpy(stored_msg_ptr->send_msg_ptr.uri_path_ptr, uri_path_ptr, uri_path_len);
     }
 
 
@@ -874,17 +871,17 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
     /* Loop all stored resending messages Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
         /* Get message ID from stored resending message */
-        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr->packet_ptr[2] << 8);
-        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr->packet_ptr[3];
+        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
+        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr->dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
                     /* * * Message found, return pointer to that stored resending message * * * */
-                    return stored_msg_ptr->send_msg_ptr;
+                    return &stored_msg_ptr->send_msg_ptr;
                 }
             }
         }
@@ -907,15 +904,15 @@ static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, 
     /* Loop all stored resending messages in Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
         /* Get message ID from stored resending message */
-        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr->packet_ptr[2] << 8);
-        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr->packet_ptr[3];
+        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
+        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr->dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
                     /* * * Message found * * */
 
                     /* Remove message from Linked list */
@@ -1343,39 +1340,30 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 
     memset(msg_ptr, 0, sizeof(coap_send_msg_s));
 
-    msg_ptr->send_msg_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_transmit_s));
+    msg_ptr->send_msg_ptr.dst_addr_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
 
-    if (msg_ptr->send_msg_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.dst_addr_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    memset(msg_ptr->send_msg_ptr, 0 , sizeof(sn_nsdl_transmit_s));
+    memset(msg_ptr->send_msg_ptr.dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
 
-    msg_ptr->send_msg_ptr->dst_addr_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
+    msg_ptr->send_msg_ptr.packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
 
-    if (msg_ptr->send_msg_ptr->dst_addr_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.packet_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    memset(msg_ptr->send_msg_ptr->dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
+    msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
 
-    msg_ptr->send_msg_ptr->packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
-
-    if (msg_ptr->send_msg_ptr->packet_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
-
-    if (msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr == NULL) {
-        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
-        return 0;
-    }
-
-    memset(msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, 0, dst_addr_ptr->addr_len);
+    memset(msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, 0, dst_addr_ptr->addr_len);
 
     return msg_ptr;
 }
@@ -1392,20 +1380,16 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr)
 {
     if (freed_send_msg_ptr != NULL) {
-        if (freed_send_msg_ptr->send_msg_ptr != NULL) {
-            if (freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr != NULL) {
+        if (freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr != NULL) {
 
-                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr);
+            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr);
 
-                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr);
-            }
-
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->packet_ptr);
-
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->uri_path_ptr);
-
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr);
+            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr);
         }
+
+        handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.packet_ptr);
+
+        handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.uri_path_ptr);
 
         handle->sn_coap_protocol_free(freed_send_msg_ptr);
     }
@@ -1423,9 +1407,7 @@ static uint16_t sn_coap_count_linked_list_size(const coap_send_msg_list_t *linke
     uint16_t total_size = 0;
 
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, linked_list_ptr) {
-        if (stored_msg_ptr->send_msg_ptr) {
-            total_size += stored_msg_ptr->send_msg_ptr->packet_len;
-        }
+        total_size += stored_msg_ptr->send_msg_ptr.packet_len;
     }
 
     return total_size;

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -291,11 +291,9 @@ void sn_coap_protocol_clear_retransmission_buffer(struct coap_s *handle)
         return;
     }
     ns_list_foreach_safe(coap_send_msg_s, tmp, &handle->linked_list_resent_msgs) {
-        if (tmp->send_msg_ptr.dst_addr_ptr) {
-            handle->sn_coap_protocol_free(tmp->send_msg_ptr.dst_addr_ptr->addr_ptr);
 
-            handle->sn_coap_protocol_free(tmp->send_msg_ptr.dst_addr_ptr);
-        }
+        handle->sn_coap_protocol_free(tmp->send_msg_ptr.dst_addr_ptr.addr_ptr);
+
         handle->sn_coap_protocol_free(tmp->send_msg_ptr.packet_ptr);
 
         handle->sn_coap_protocol_free(tmp->send_msg_ptr.uri_path_ptr);
@@ -746,17 +744,17 @@ int8_t sn_coap_protocol_exec(struct coap_s *handle, uint32_t current_time)
                         if (tmp_coap_hdr_ptr != 0) {
                             tmp_coap_hdr_ptr->coap_status = COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED;
 
-                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
+                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                             sn_coap_parser_release_allocated_coap_msg_mem(stored_msg_ptr->coap, tmp_coap_hdr_ptr);
                         }
                     }
                     /* Remove message from Linked list */
-                    sn_coap_protocol_linked_list_send_msg_remove(handle, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, temp_msg_id);
+                    sn_coap_protocol_linked_list_send_msg_remove(handle, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr, temp_msg_id);
                 } else {
                     /* Send message  */
                     stored_msg_ptr->coap->sn_coap_tx_callback(stored_msg_ptr->send_msg_ptr.packet_ptr,
-                            stored_msg_ptr->send_msg_ptr.packet_len, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
+                            stored_msg_ptr->send_msg_ptr.packet_len, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                     /* * * Count new Resending time  * * */
                     stored_msg_ptr->resending_time = current_time + (((uint32_t)(handle->sn_coap_resending_intervall * RESPONSE_RANDOM_FACTOR)) <<
@@ -829,10 +827,10 @@ static void sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, s
     memcpy(stored_msg_ptr->send_msg_ptr.packet_ptr, send_packet_data_ptr, send_packet_data_len);
 
     /* Filling of sn_nsdl_addr_s */
-    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->type = dst_addr_ptr->type;
-    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_len = dst_addr_ptr->addr_len;
-    memcpy(stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
-    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port = dst_addr_ptr->port;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr.type = dst_addr_ptr->type;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_len = dst_addr_ptr->addr_len;
+    memcpy(stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port = dst_addr_ptr->port;
 
     stored_msg_ptr->coap = handle;
     stored_msg_ptr->param = param;
@@ -877,9 +875,9 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port == src_addr_ptr->port) {
                     /* * * Message found, return pointer to that stored resending message * * * */
                     return &stored_msg_ptr->send_msg_ptr;
                 }
@@ -910,9 +908,9 @@ static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port == src_addr_ptr->port) {
                     /* * * Message found * * */
 
                     /* Remove message from Linked list */
@@ -1340,15 +1338,6 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 
     memset(msg_ptr, 0, sizeof(coap_send_msg_s));
 
-    msg_ptr->send_msg_ptr.dst_addr_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
-
-    if (msg_ptr->send_msg_ptr.dst_addr_ptr == NULL) {
-        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
-        return 0;
-    }
-
-    memset(msg_ptr->send_msg_ptr.dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
-
     msg_ptr->send_msg_ptr.packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
 
     if (msg_ptr->send_msg_ptr.packet_ptr == NULL) {
@@ -1356,14 +1345,14 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
         return 0;
     }
 
-    msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
+    msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
 
-    if (msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    memset(msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, 0, dst_addr_ptr->addr_len);
+    memset(msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, 0, dst_addr_ptr->addr_len);
 
     return msg_ptr;
 }
@@ -1380,12 +1369,8 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr)
 {
     if (freed_send_msg_ptr != NULL) {
-        if (freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr != NULL) {
 
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr);
-
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr);
-        }
+        handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr);
 
         handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.packet_ptr);
 


### PR DESCRIPTION
This PR contains just few microscopic ROM memory savings plus some more involved changes which mebed structs instead of allocating them separately. These save total 352 bytes of flash on GCC compilation.