### PR TITLE
Include token to block1 response message

### DIFF
--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -795,7 +795,6 @@ int8_t sn_coap_protocol_exec(struct coap_s *handle, uint32_t current_time)
 
                         if (tmp_coap_hdr_ptr != 0) {
                             tmp_coap_hdr_ptr->coap_status = COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED;
-
                             stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, stored_msg_ptr->send_msg_ptr->dst_addr_ptr, stored_msg_ptr->param);
 
                             sn_coap_parser_release_allocated_coap_msg_mem(stored_msg_ptr->coap, tmp_coap_hdr_ptr);
@@ -1678,6 +1677,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                 // Response with COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE if the payload size is more than we can handle
                 tr_debug("sn_coap_handle_blockwise_message - block1 received - incoming size: [%d]", received_coap_msg_ptr->options_list_ptr->size1);
+
                 uint32_t max_size = SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE;
                 if (received_coap_msg_ptr->options_list_ptr->size1 > max_size) {
                     // Include maximum size that stack can handle into response
@@ -1705,6 +1705,13 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 }
 
                 src_coap_blockwise_ack_msg_ptr->msg_id = received_coap_msg_ptr->msg_id;
+
+                // Copy token to response
+                src_coap_blockwise_ack_msg_ptr->token_ptr = handle->sn_coap_protocol_malloc(received_coap_msg_ptr->token_len);
+                if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
+                    memcpy(src_coap_blockwise_ack_msg_ptr->token_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+                    src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
+                }
 
                 dst_packed_data_needed_mem = sn_coap_builder_calc_needed_packet_data_size_2(src_coap_blockwise_ack_msg_ptr, handle->sn_coap_block_data_size);
 

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -762,7 +762,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
     sn_coap_builder_stub.expectedUint16 = 1;
 
-    retCounter = 9;
+    retCounter = 10;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL != ret );
     CHECK(COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING == ret->coap_status);
@@ -810,7 +810,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 65535;
 
-    retCounter = 10;
+    retCounter = 11;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL != ret );
 
@@ -2281,14 +2281,14 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
     sn_coap_builder_stub.expectedUint16 = 1;
 
     // Success
-    retCounter = 9;
+    retCounter = 10;
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     sn_coap_protocol_block_remove(handle,addr,packet_data_len,packet_data_ptr);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
 
     // Ports does not match
-    retCounter = 18;
+    retCounter = 19;
     sn_coap_parser_stub.expectedHeader->msg_id = 14;
     addr->port = 5600;
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
@@ -2298,7 +2298,7 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
 
     // Addresses does not match
-    retCounter = 18;
+    retCounter = 19;
     sn_coap_parser_stub.expectedHeader->msg_id = 15;
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 2);


### PR DESCRIPTION
 - Fixes error: IOTCLT-1880 Lwm2m blockwise data transfer (using Block1 option) with Leshan not working