### PR TITLE
Change resending_queue_bytes datatype

### DIFF
--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -225,7 +225,7 @@ struct coap_s {
     uint32_t system_time;    /* System time seconds */
     uint16_t sn_coap_block_data_size;
     uint8_t sn_coap_resending_queue_msgs;
-    uint8_t sn_coap_resending_queue_bytes;
+    uint32_t sn_coap_resending_queue_bytes;
     uint8_t sn_coap_resending_count;
     uint8_t sn_coap_resending_intervall;
     uint8_t sn_coap_duplication_buffer_size;


### PR DESCRIPTION
This change is needed to allow proper queue sizes. uint16_t could be also used, but the uint32_t should make sure we don't have to make it bigger in future.