### PR TITLE
Allow disabling resendings by defining SN_COAP_DISABLE_RESENDINGS

### DIFF
--- a/mbed-coap/sn_config.h
+++ b/mbed-coap/sn_config.h
@@ -55,6 +55,15 @@
 #undef COAP_DISABLE_OBS_FEATURE
 
 /**
+ * \def SN_COAP_DISABLE_RESENDINGS
+ *
+ * \brief Disables resending feature. Resending feature should not be needed
+ * when using CoAP with TCP transport for example. By default resendings are
+ * enabled. Set to 1 to disable.
+ */
+#undef SN_COAP_DISABLE_RESENDINGS          /* 0 */ // < Default re-sending are not disabled. Set to 1 to disable re-sendings
+
+/**
  * \def SN_COAP_RESENDING_QUEUE_SIZE_MSGS
  *
  * \brief Sets the number of messages stored

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -39,7 +39,11 @@ struct sn_coap_hdr_;
 /* * * * * * * * * * * */
 
 /* * For Message resending * */
+#ifdef SN_COAP_DISABLE_RESENDINGS
+#define ENABLE_RESENDINGS                               0 /* Disable resendings */
+#else
 #define ENABLE_RESENDINGS                               1   /**< Enable / Disable resending from library in building */
+#endif
 
 #define SN_COAP_RESENDING_MAX_COUNT                     3   /**< Default number of re-sendings  */
 


### PR DESCRIPTION
When using CoAP over TCP we don't need resendings at all so add SN_COAP_DISABLE_RESENDINGS macro for configuring the ENABLE_RESENDINGS flag.