### PR TITLE
Do not add duplicate message into received block payload list

### DIFF
--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -1266,6 +1266,15 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
         return;
     }
 
+    // Do not add duplicates to list, this could happen if server needs to retransmit block message again
+    ns_list_foreach(coap_blockwise_payload_s, payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
+        if (0 == memcmp(addr_ptr->addr_ptr, payload_info_ptr->addr_ptr, addr_ptr->addr_len)) {
+            if (payload_info_ptr->port == addr_ptr->port && payload_info_ptr->block_number == block_number) {
+                return;
+            }
+        }
+    }
+
     coap_blockwise_payload_s *stored_blockwise_payload_ptr = NULL;
 
     /* * * * Allocating memory for stored Payload  * * * */

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -628,7 +628,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x10;
     sn_coap_parser_stub.expectedHeader->msg_id = 5;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
@@ -649,7 +649,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x20;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
     payload = (uint8_t*)malloc(17);
@@ -669,7 +669,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x30;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
 
@@ -689,7 +689,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x40;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
     payload = (uint8_t*)malloc(17);
@@ -709,7 +709,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x50;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
     payload = (uint8_t*)malloc(17);
@@ -792,7 +792,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x58;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
     payload = (uint8_t*)malloc(17);
@@ -814,7 +814,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x0F;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x68;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_POST;
     payload = (uint8_t*)malloc(17);
@@ -835,7 +835,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x78;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_PUT;
     payload = (uint8_t*)malloc(17);
@@ -859,7 +859,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
-    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x08;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x88;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
     payload = (uint8_t*)malloc(17);


### PR DESCRIPTION
Fix error: IOTCLT-2539 Block wise messaging call-backs not working logically
This could happen if server needs to retransmit block message again