### PR TITLE
Add block transfer status

### DIFF
--- a/mbed-coap/sn_coap_header.h
+++ b/mbed-coap/sn_coap_header.h
@@ -158,8 +158,16 @@ typedef enum sn_coap_status_ {
     COAP_STATUS_PARSER_BLOCKWISE_MSG_REJECTED  = 5, /**< Blockwise message received but not supported by compiling switch */
     COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED  = 6, /**< Blockwise message fully received and returned to app.
                                                          User must take care of releasing whole payload of the blockwise messages */
-    COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED = 7  /**< When re-transmissions have been done and ACK not received, CoAP library calls
+    COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED = 7, /**< When re-transmissions have been done and ACK not received, CoAP library calls
                                                          RX callback with this status */
+
+    COAP_STATUS_BUILDER_BLOCK_SENDING_FAILED   = 8, /**< Blockwise message sending timeout.
+                                                         The msg_id in sn_coap_hdr_s* parameter of RX callback is set to the same value
+                                                         as in the first block sent, and parameter sn_nsdl_addr_s* is set as NULL.  */
+    COAP_STATUS_BUILDER_BLOCK_SENDING_DONE     = 9  /**< Blockwise message sending, last block sent.
+                                                         The msg_id in sn_coap_hdr_s* parameter of RX callback is set to the same value
+                                                         as in the first block sent, and parameter sn_nsdl_addr_s* is set as NULL. */
+
 } sn_coap_status_e;
 
 

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -185,7 +185,10 @@ typedef struct coap_blockwise_msg_ {
     sn_coap_hdr_s       *coap_msg_ptr;
     struct coap_s       *coap;      /* CoAP library handle */
 
-    ns_list_link_t     link;
+    void                *param;
+    uint16_t            msg_id;
+
+    ns_list_link_t      link;
 } coap_blockwise_msg_s;
 
 typedef NS_LIST_HEAD(coap_blockwise_msg_s, link) coap_blockwise_msg_list_t;


### PR DESCRIPTION
* add status for successfull and failing block case
* call sn_coap_rx_callback when block transfer is done or fails
* this enables the user of the library to know what happened to the blocks.