### PR TITLE
Fix CoAP request blockwise response handling

### DIFF
--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -201,6 +201,8 @@ typedef struct coap_blockwise_payload_ {
     uint8_t             *addr_ptr;
     uint16_t            port;
     uint32_t            block_number;
+    uint8_t             *token_ptr;
+    uint8_t             token_len;
 
     uint16_t            payload_len;
     uint8_t             *payload_ptr;

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -55,12 +55,12 @@ static void                  sn_coap_protocol_linked_list_duplication_info_remov
 #endif
 #if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not used at all, this part of code will not be compiled */
 static void                  sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *handle, coap_blockwise_msg_s *removed_msg_ptr);
-static void                  sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *handle, sn_nsdl_addr_s *addr_ptr, uint16_t stored_payload_len, uint8_t *stored_payload_ptr, uint32_t block_number);
-static uint8_t              *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length);
-static bool                  sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint32_t block_number);
+static void                  sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *handle, sn_nsdl_addr_s *addr_ptr, uint16_t stored_payload_len, uint8_t *stored_payload_ptr, uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
+static uint8_t              *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length, uint8_t *token_ptr, uint8_t token_len);
+static bool                  sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s *handle, coap_blockwise_payload_s *removed_payload_ptr);
-static void                  sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(struct coap_s *handle);
-static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr);
+static void                  sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(struct coap_s *handle, uint8_t *token_ptr, uint8_t token_len);
+static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len);
 static void                  sn_coap_protocol_handle_blockwise_timout(struct coap_s *handle);
 static sn_coap_hdr_s        *sn_coap_handle_blockwise_message(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr, void *param);
 static sn_coap_hdr_s        *sn_coap_protocol_copy_header(struct coap_s *handle, sn_coap_hdr_s *source_header_ptr);
@@ -535,9 +535,7 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         stored_blockwise_msg_ptr->param = param;
         stored_blockwise_msg_ptr->msg_id = stored_blockwise_msg_ptr->coap_msg_ptr->msg_id;
         ns_list_add_to_end(&handle->linked_list_blockwise_sent_msgs, stored_blockwise_msg_ptr);
-    }
-
-    else if (src_coap_msg_ptr->msg_code == COAP_MSG_CODE_REQUEST_GET) {
+    } else if (src_coap_msg_ptr->msg_code <= COAP_MSG_CODE_REQUEST_DELETE) {
         /* Add message to linked list - response can be in blocks and we need header to build response.. */
         coap_blockwise_msg_s *stored_blockwise_msg_ptr;
 
@@ -1258,6 +1256,8 @@ static void sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *han
 static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *handle, sn_nsdl_addr_s *addr_ptr,
         uint16_t stored_payload_len,
         uint8_t *stored_payload_ptr,
+        uint8_t *token_ptr,
+        uint8_t token_len,
         uint32_t block_number)
 {
     if (!addr_ptr || !stored_payload_len || !stored_payload_ptr) {
@@ -1266,8 +1266,15 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
 
     // Do not add duplicates to list, this could happen if server needs to retransmit block message again
     ns_list_foreach(coap_blockwise_payload_s, payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
-        if (0 == memcmp(addr_ptr->addr_ptr, payload_info_ptr->addr_ptr, addr_ptr->addr_len)) {
-            if (payload_info_ptr->port == addr_ptr->port && payload_info_ptr->block_number == block_number) {
+        if ((0 == memcmp(addr_ptr->addr_ptr, payload_info_ptr->addr_ptr, addr_ptr->addr_len)) && (payload_info_ptr->port == addr_ptr->port)) {
+            if (token_ptr) {
+                if (!payload_info_ptr->token_ptr || (payload_info_ptr->token_len != token_len) || (memcmp(payload_info_ptr->token_ptr, token_ptr, token_len))) {
+                    continue;
+                }
+            } else if (payload_info_ptr->token_ptr) {
+                continue;
+            }
+            if (payload_info_ptr->block_number == block_number) {
                 return;
             }
         }
@@ -1309,6 +1316,25 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
         return;
     }
 
+    /* Allocate & copy token number */
+    if (token_ptr && token_len) {
+        stored_blockwise_payload_ptr->token_ptr = handle->sn_coap_protocol_malloc(token_len);
+
+        if(!stored_blockwise_payload_ptr->token_ptr) {
+            tr_error("sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate token pointer!");
+            handle->sn_coap_protocol_free(stored_blockwise_payload_ptr->addr_ptr);
+            handle->sn_coap_protocol_free(stored_blockwise_payload_ptr->payload_ptr);
+            handle->sn_coap_protocol_free(stored_blockwise_payload_ptr);
+            return;
+        }
+
+        memcpy(stored_blockwise_payload_ptr->token_ptr, token_ptr, token_len);
+        stored_blockwise_payload_ptr->token_len = token_len;
+    } else {
+        stored_blockwise_payload_ptr->token_ptr = NULL;
+        stored_blockwise_payload_ptr->token_len = 0;
+    }
+
     /* * * * Filling fields of stored Payload  * * * */
 
     stored_blockwise_payload_ptr->timestamp = handle->system_time;
@@ -1323,7 +1349,6 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
     stored_blockwise_payload_ptr->block_number = block_number;
 
     /* * * * Storing Payload to Linked list  * * * */
-
     ns_list_add_to_end(&handle->linked_list_blockwise_received_payloads, stored_blockwise_payload_ptr);
 }
 
@@ -1339,19 +1364,23 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
  *         list or NULL if payload not found
  *****************************************************************************/
 
-static uint8_t *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length)
+static uint8_t *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length, uint8_t *token_ptr, uint8_t token_len)
 {
     /* Loop all stored blockwise payloads in Linked list */
     ns_list_foreach(coap_blockwise_payload_s, stored_payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
-        /* If payload's Source address is same than is searched */
-        if (0 == memcmp(src_addr_ptr->addr_ptr, stored_payload_info_ptr->addr_ptr, src_addr_ptr->addr_len)) {
-            /* If payload's Source address port is same than is searched */
-            if (stored_payload_info_ptr->port == src_addr_ptr->port) {
-                /* * * Correct Payload found * * * */
-                *payload_length = stored_payload_info_ptr->payload_len;
-
-                return stored_payload_info_ptr->payload_ptr;
+        /* If payload's Source address and port is same than is searched */
+        if ((0 == memcmp(src_addr_ptr->addr_ptr, stored_payload_info_ptr->addr_ptr, src_addr_ptr->addr_len)) && (stored_payload_info_ptr->port == src_addr_ptr->port)) {
+            /* Check token */
+            if (token_ptr) {
+                if (!stored_payload_info_ptr->token_ptr || (token_len != stored_payload_info_ptr->token_len) || (memcmp(stored_payload_info_ptr->token_ptr, token_ptr, token_len))) {
+                    continue;
+                }
+            } else if (stored_payload_info_ptr->token_ptr) {
+                continue;
             }
+            /* * * Correct Payload found * * * */
+            *payload_length = stored_payload_info_ptr->payload_len;
+            return stored_payload_info_ptr->payload_ptr;
         }
     }
 
@@ -1360,21 +1389,29 @@ static uint8_t *sn_coap_protocol_linked_list_blockwise_payload_search(struct coa
 
 static bool sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle,
                                                                                    sn_nsdl_addr_s *src_addr_ptr,
+                                                                                   uint8_t *token_ptr,
+                                                                                   uint8_t token_len,
                                                                                    uint32_t block_number)
 {
     /* Loop all stored blockwise payloads in Linked list */
     ns_list_foreach(coap_blockwise_payload_s, stored_payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
-        /* If payload's Source address is same than is searched */
-        if (0 == memcmp(src_addr_ptr->addr_ptr, stored_payload_info_ptr->addr_ptr, src_addr_ptr->addr_len)) {
-            /* If payload's Source address port is same than is searched */
-            if (stored_payload_info_ptr->port == src_addr_ptr->port) {
-                // Check that incoming block number matches to last received one
-                if (block_number - 1 == stored_payload_info_ptr->block_number) {
-                    return true;
+        /* If payload's Source address and port is same than is searched */
+        if ((0 == memcmp(src_addr_ptr->addr_ptr, stored_payload_info_ptr->addr_ptr, src_addr_ptr->addr_len)) && (stored_payload_info_ptr->port == src_addr_ptr->port)) {
+            /* Check token number */
+            if (token_ptr) {
+                if (!stored_payload_info_ptr->token_ptr || (token_len != stored_payload_info_ptr->token_len) || (memcmp(stored_payload_info_ptr->token_ptr, token_ptr, token_len))) {
+                    continue;
                 }
+            } else if (stored_payload_info_ptr->token_ptr) {
+                continue;
+            }
+            // Check that incoming block number matches to last received one
+            if (block_number - 1 == stored_payload_info_ptr->block_number) {
+                return true;
             }
         }
     }
+
     return false;
 }
 
@@ -1384,15 +1421,23 @@ static bool sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(
  * \brief Removes current stored blockwise paylod from Linked list
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(struct coap_s *handle)
+static void sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(struct coap_s *handle, uint8_t *token_ptr, uint8_t token_len)
 {
-    coap_blockwise_payload_s *removed_payload_ptr;
-
     /* Remove oldest node in Linked list*/
-    removed_payload_ptr = ns_list_get_first(&handle->linked_list_blockwise_received_payloads);
-
-    if (removed_payload_ptr != NULL) {
-        sn_coap_protocol_linked_list_blockwise_payload_remove(handle, removed_payload_ptr);
+    if (token_ptr) {
+        ns_list_foreach(coap_blockwise_payload_s, removed_payload_ptr, &handle->linked_list_blockwise_received_payloads) {
+            if ((token_len == removed_payload_ptr->token_len) && !memcmp(removed_payload_ptr->token_ptr, token_ptr, token_len)) {
+                sn_coap_protocol_linked_list_blockwise_payload_remove(handle, removed_payload_ptr);
+                return;
+            }
+        }
+    } else {
+        ns_list_foreach(coap_blockwise_payload_s, removed_payload_ptr, &handle->linked_list_blockwise_received_payloads) {
+            if (!removed_payload_ptr->token_ptr) {
+                sn_coap_protocol_linked_list_blockwise_payload_remove(handle, removed_payload_ptr);
+                return;
+            }
+        }
     }
 }
 
@@ -1420,6 +1465,11 @@ static void sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s 
         removed_payload_ptr->payload_ptr = 0;
     }
 
+    if (removed_payload_ptr->token_ptr != NULL) {
+        handle->sn_coap_protocol_free(removed_payload_ptr->token_ptr);
+        removed_payload_ptr->token_ptr = 0;
+    }
+
     handle->sn_coap_protocol_free(removed_payload_ptr);
     removed_payload_ptr = 0;
 }
@@ -1434,18 +1484,23 @@ static void sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s 
  * \return Return value is length of Payloads as bytes
  *****************************************************************************/
 
-static uint32_t sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr)
+static uint32_t sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len)
 {
     uint32_t ret_whole_payload_len = 0;
     /* Loop all stored blockwise payloads in Linked list */
     ns_list_foreach(coap_blockwise_payload_s, searched_payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
-        /* If payload's Source address is same than is searched */
-        if (0 == memcmp(src_addr_ptr->addr_ptr, searched_payload_info_ptr->addr_ptr, src_addr_ptr->addr_len)) {
-            /* If payload's Source address port is same than is searched */
-            if (searched_payload_info_ptr->port == src_addr_ptr->port) {
-                /* * * Correct Payload found * * * */
-                ret_whole_payload_len += searched_payload_info_ptr->payload_len;
+        /* If payload's Source address and port is same than is searched */
+        if ((0 == memcmp(src_addr_ptr->addr_ptr, searched_payload_info_ptr->addr_ptr, src_addr_ptr->addr_len)) && (searched_payload_info_ptr->port == src_addr_ptr->port)) {
+            /* Check token */
+            if (token_ptr) {
+                if(!searched_payload_info_ptr->token_ptr || (token_len != searched_payload_info_ptr->token_len) || (memcmp(searched_payload_info_ptr->token_ptr, token_ptr, token_len))) {
+                    continue;
+                }
+            } else if (searched_payload_info_ptr->token_ptr) {
+                continue;
             }
+            /* * * Correct Payload found * * * */
+            ret_whole_payload_len += searched_payload_info_ptr->payload_len;
         }
     }
 
@@ -1593,14 +1648,14 @@ static uint16_t sn_coap_count_linked_list_size(const coap_send_msg_list_t *linke
 #endif
 
 #if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
-void sn_coap_protocol_remove_sent_blockwise_message(struct coap_s *handle, uint16_t message_id)
+void sn_coap_protocol_remove_sent_blockwise_message(struct coap_s *handle, uint16_t msg_id)
 {
     if (!handle) {
         return;
     }
 
     ns_list_foreach_safe(coap_blockwise_msg_s, tmp, &handle->linked_list_blockwise_sent_msgs) {
-        if (tmp->coap == handle && tmp->coap_msg_ptr && tmp->coap_msg_ptr->msg_id == message_id) {
+        if (tmp->coap == handle && tmp->coap_msg_ptr && tmp->coap_msg_ptr->msg_id == msg_id) {
             handle->sn_coap_protocol_free(tmp->coap_msg_ptr->payload_ptr);
             sn_coap_parser_release_allocated_coap_msg_mem(tmp->coap, tmp->coap_msg_ptr);
             ns_list_remove(&handle->linked_list_blockwise_sent_msgs, tmp);
@@ -1641,6 +1696,28 @@ void sn_coap_protocol_block_remove(struct coap_s *handle, sn_nsdl_addr_s *source
         }
     }
 }
+
+/****************************************************************************
+ * \fn coap_blockwise_msg_s *sn_coap_stored_blockwise_msg_get(struct coap_s *handle, sn_coap_hdr_s *received_coap_msg_ptr)
+ *
+ * \brief Get blockwise message from list
+ *
+ * \param *handle Pointer to the coap handle structure
+ * \param *received_coap_msg_ptr Pointer to parsed CoAP message structure
+ *****************************************************************************/
+static coap_blockwise_msg_s *sn_coap_stored_blockwise_msg_get(struct coap_s *handle, sn_coap_hdr_s *received_coap_msg_ptr)
+{
+    ns_list_foreach(coap_blockwise_msg_s, msg, &handle->linked_list_blockwise_sent_msgs) {
+        if (!received_coap_msg_ptr->token_ptr && !msg->coap_msg_ptr->token_ptr) {
+            return msg;
+        } else if ((received_coap_msg_ptr->token_len == msg->coap_msg_ptr->token_len) && (!memcmp(received_coap_msg_ptr->token_ptr, msg->coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len))) {
+            return msg;
+        }
+    }
+
+    return NULL;
+}
+
 /**************************************************************************//**
  * \fn static int8_t sn_coap_handle_blockwise_message(void)
  *
@@ -1745,10 +1822,12 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
 #if ENABLE_RESENDINGS
                     uint32_t resend_time = sn_coap_calculate_new_resend_time(handle->system_time, handle->sn_coap_resending_intervall, 0);
-                    sn_coap_protocol_linked_list_send_msg_store(handle, src_addr_ptr,
-                            dst_packed_data_needed_mem,
-                            dst_ack_packet_data_ptr,
-                            resend_time, param);
+                    if (src_coap_blockwise_ack_msg_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE) {
+                        sn_coap_protocol_linked_list_send_msg_store(handle, src_addr_ptr,
+                                dst_packed_data_needed_mem,
+                                dst_ack_packet_data_ptr,
+                                resend_time, param);
+                    }
 #endif
 
                     handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
@@ -1780,9 +1859,12 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             // Check that incoming block number is in order.
             uint32_t block_number = received_coap_msg_ptr->options_list_ptr->block1 >> 4;
             bool blocks_in_order = true;
+
             if (block_number > 0 &&
                 !sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(handle,
                                                                                      src_addr_ptr,
+                                                                                     received_coap_msg_ptr->token_ptr,
+                                                                                     received_coap_msg_ptr->token_len,
                                                                                      block_number)) {
                 blocks_in_order = false;
             }
@@ -1791,6 +1873,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                                                                  src_addr_ptr,
                                                                  received_coap_msg_ptr->payload_len,
                                                                  received_coap_msg_ptr->payload_ptr,
+                                                                 received_coap_msg_ptr->token_ptr,
+                                                                 received_coap_msg_ptr->token_len,
                                                                  block_number);
 
             /* If not last block (more value is set) */
@@ -1842,7 +1926,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                          tr_error("sn_coap_handle_blockwise_message - (recv block1) COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE!");
                          src_coap_blockwise_ack_msg_ptr->msg_code = COAP_MSG_CODE_RESPONSE_REQUEST_ENTITY_TOO_LARGE;
                          src_coap_blockwise_ack_msg_ptr->options_list_ptr->size1 = handle->sn_coap_block_data_size;
-                         sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle);
+                         sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                     }
 
                     if (block_temp > sn_coap_convert_block_size(handle->sn_coap_block_data_size)) {
@@ -1888,8 +1972,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                 /* Store last Blockwise payload to Linked list */
                 uint16_t payload_len            = 0;
-                uint8_t *payload_ptr            = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len);
-                uint32_t whole_payload_len      = sn_coap_protocol_linked_list_blockwise_payloads_get_len(handle, src_addr_ptr);
+                uint8_t *payload_ptr            = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+                uint32_t whole_payload_len      = sn_coap_protocol_linked_list_blockwise_payloads_get_len(handle, src_addr_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                 uint8_t *temp_whole_payload_ptr = NULL;
 
                 temp_whole_payload_ptr = handle->sn_coap_protocol_malloc(whole_payload_len);
@@ -1908,8 +1992,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 while (payload_ptr != NULL) {
                     memcpy(temp_whole_payload_ptr, payload_ptr, payload_len);
                     temp_whole_payload_ptr += payload_len;
-                    sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle);
-                    payload_ptr = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len);
+                    sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+                    payload_ptr = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                 }
                 received_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED;
             }
@@ -1931,6 +2015,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                                                                      src_addr_ptr,
                                                                      received_coap_msg_ptr->payload_len,
                                                                      received_coap_msg_ptr->payload_ptr,
+                                                                     received_coap_msg_ptr->token_ptr,
+                                                                     received_coap_msg_ptr->token_len,
                                                                      received_coap_msg_ptr->options_list_ptr->block2 >> 4);
                 /* If not last block (more value is set) */
                 if (received_coap_msg_ptr->options_list_ptr->block2 & 0x08) {
@@ -1982,28 +2068,26 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
 
                     /* Set BLOCK2 (subsequent) GET msg code and copy uri path from previous msg*/
-                    if (received_coap_msg_ptr->msg_code == COAP_MSG_CODE_RESPONSE_CONTENT) {
-                        src_coap_blockwise_ack_msg_ptr->msg_code = COAP_MSG_CODE_REQUEST_GET;
-                        if (previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_ptr) {
-                            src_coap_blockwise_ack_msg_ptr->uri_path_len = previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len;
-                            src_coap_blockwise_ack_msg_ptr->uri_path_ptr = handle->sn_coap_protocol_malloc(previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len);
-                            if (!src_coap_blockwise_ack_msg_ptr->uri_path_ptr) {
-                                sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
-                                tr_error("sn_coap_handle_blockwise_message - failed to allocate for uri path ptr!");
-                                return NULL;
-                            }
-                            memcpy(src_coap_blockwise_ack_msg_ptr->uri_path_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len);
+                    src_coap_blockwise_ack_msg_ptr->msg_code = previous_blockwise_msg_ptr->coap_msg_ptr->msg_code;
+                    if (previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_ptr) {
+                        src_coap_blockwise_ack_msg_ptr->uri_path_len = previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len;
+                        src_coap_blockwise_ack_msg_ptr->uri_path_ptr = handle->sn_coap_protocol_malloc(previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len);
+                        if (!src_coap_blockwise_ack_msg_ptr->uri_path_ptr) {
+                            sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
+                            tr_error("sn_coap_handle_blockwise_message - failed to allocate for uri path ptr!");
+                            return NULL;
                         }
-                        if (previous_blockwise_msg_ptr->coap_msg_ptr->token_ptr) {
-                            src_coap_blockwise_ack_msg_ptr->token_len = previous_blockwise_msg_ptr->coap_msg_ptr->token_len;
-                            src_coap_blockwise_ack_msg_ptr->token_ptr = handle->sn_coap_protocol_malloc(previous_blockwise_msg_ptr->coap_msg_ptr->token_len);
-                            if (!src_coap_blockwise_ack_msg_ptr->token_ptr) {
-                                sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
-                                tr_error("sn_coap_handle_blockwise_message - failed to allocate for token ptr!");
-                                return NULL;
-                            }
-                            memcpy(src_coap_blockwise_ack_msg_ptr->token_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->token_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->token_len);
+                        memcpy(src_coap_blockwise_ack_msg_ptr->uri_path_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len);
+                    }
+                    if (previous_blockwise_msg_ptr->coap_msg_ptr->token_ptr) {
+                        src_coap_blockwise_ack_msg_ptr->token_len = previous_blockwise_msg_ptr->coap_msg_ptr->token_len;
+                        src_coap_blockwise_ack_msg_ptr->token_ptr = handle->sn_coap_protocol_malloc(previous_blockwise_msg_ptr->coap_msg_ptr->token_len);
+                        if (!src_coap_blockwise_ack_msg_ptr->token_ptr) {
+                            sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
+                            tr_error("sn_coap_handle_blockwise_message - failed to allocate for token ptr!");
+                            return NULL;
                         }
+                        memcpy(src_coap_blockwise_ack_msg_ptr->token_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->token_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->token_len);
                     }
 
                     ns_list_remove(&handle->linked_list_blockwise_sent_msgs, previous_blockwise_msg_ptr);
@@ -2095,8 +2179,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                     /* Store last Blockwise payload to Linked list */
                     uint16_t payload_len            = 0;
-                    uint8_t *payload_ptr            = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len);
-                    uint16_t whole_payload_len      = sn_coap_protocol_linked_list_blockwise_payloads_get_len(handle, src_addr_ptr);
+                    uint8_t *payload_ptr            = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+                    uint16_t whole_payload_len      = sn_coap_protocol_linked_list_blockwise_payloads_get_len(handle, src_addr_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                     uint8_t *temp_whole_payload_ptr = NULL;
 
                     temp_whole_payload_ptr = handle->sn_coap_protocol_malloc(whole_payload_len);
@@ -2114,8 +2198,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                         temp_whole_payload_ptr += payload_len;
 
-                        sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle);
-                        payload_ptr = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len);
+                        sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+                        payload_ptr = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                     }
                     received_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED;
 
@@ -2128,7 +2212,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
         else {
             //Get message by using block number
             //NOTE: Getting the first from list might not be correct one
-            coap_blockwise_msg_s *stored_blockwise_msg_temp_ptr = ns_list_get_first(&handle->linked_list_blockwise_sent_msgs);
+            coap_blockwise_msg_s *stored_blockwise_msg_temp_ptr = sn_coap_stored_blockwise_msg_get(handle, received_coap_msg_ptr);
             if (stored_blockwise_msg_temp_ptr) {
                 uint16_t block_size;
                 uint32_t block_number;
@@ -2137,7 +2221,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 block_number = received_coap_msg_ptr->options_list_ptr->block2 >> 4;
                 block_temp = received_coap_msg_ptr->options_list_ptr->block2 & 0x07;
                 block_size = 1u << (block_temp + 4);
-
                 /* Build response message */
                 src_coap_blockwise_ack_msg_ptr = stored_blockwise_msg_temp_ptr->coap_msg_ptr;
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -2110,10 +2110,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                     if (dst_ack_packet_data_ptr == NULL) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate packet!");
-                        handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->options_list_ptr);
-                        src_coap_blockwise_ack_msg_ptr->options_list_ptr = 0;
-                        handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                        src_coap_blockwise_ack_msg_ptr = 0;
+                        sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
@@ -2124,10 +2121,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         tr_error("sn_coap_handle_blockwise_message - (send block2) builder failed!");
                         handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
                         dst_ack_packet_data_ptr = 0;
-                        handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->options_list_ptr);
-                        src_coap_blockwise_ack_msg_ptr->options_list_ptr = 0;
-                        handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                        src_coap_blockwise_ack_msg_ptr = 0;
+                        sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
@@ -2140,10 +2134,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate blockwise message!");
                         handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
                         dst_ack_packet_data_ptr = 0;
-                        handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->options_list_ptr);
-                        src_coap_blockwise_ack_msg_ptr->options_list_ptr = 0;
-                        handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                        src_coap_blockwise_ack_msg_ptr = 0;
+                        sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return 0;
                     }
@@ -2282,9 +2273,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         handle->sn_coap_protocol_free(original_payload_ptr);
                         original_payload_ptr = NULL;
                     }
-                    handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->options_list_ptr);
-                    src_coap_blockwise_ack_msg_ptr->options_list_ptr = 0;
-                    handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                     stored_blockwise_msg_temp_ptr->coap_msg_ptr = NULL;
                     return NULL;
                 }

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -237,7 +237,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr.msg_id = 100;
     hdr.msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_builder_stub.expectedInt16 = 0;
-    retCounter = 2;
+    retCounter = 3;
 
     coap_duplication_info_s *duplicate = (coap_duplication_info_s*)malloc(sizeof(coap_duplication_info_s));
     memset(duplicate, 0, sizeof(coap_duplication_info_s));
@@ -332,7 +332,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
-    retCounter = 3;
+    retCounter = 4;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -48,6 +48,7 @@ TEST_GROUP(libCoap_protocol)
 void* myMalloc(uint16_t size)
 {
     if( retCounter > 0 ){
+        int a = retCounter;
         retCounter--;
         return malloc(size);
     }else {
@@ -632,6 +633,8 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     sn_coap_parser_stub.expectedHeader->msg_id = 5;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
+    sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
+
     payload = (uint8_t*)malloc(17);
     sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
     sn_coap_parser_stub.expectedHeader->payload_len = 17;
@@ -664,6 +667,31 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+    sn_coap_parser_stub.expectedHeader->msg_id = 700;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x20;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
+    payload = (uint8_t*)malloc(17);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 17;
+
+    uint32_t token = 1000;
+    sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(sizeof(uint32_t));
+    memcpy(sn_coap_parser_stub.expectedHeader->token_ptr, &token, sizeof(uint32_t));
+
+    retCounter = 6;
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
+    free(payload);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 8;
 
     list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
@@ -674,6 +702,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
 
     retCounter = 6;
+
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED == ret->coap_status );
     free(ret->payload_ptr);
@@ -1467,7 +1496,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     sn_coap_protocol_destroy(handle);
     retCounter = 1;
-    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, null_rx_cb);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -1522,6 +1551,127 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL != ret );
     CHECK( COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status );
+    free(payload);
+    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
+    sn_coap_protocol_destroy(handle);
+
+    // sn_coap_handle_blockwise_message - (recv block2) set more bit
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, null_rx_cb);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+    sn_coap_parser_stub.expectedHeader->msg_id = 20;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0x08;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
+    payload = (uint8_t*)malloc(17);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 17;
+    sn_coap_parser_stub.expectedHeader->token_len = 4;
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(4);
+    memset(sn_coap_parser_stub.expectedHeader->token_ptr, '1', 4);
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+
+    tmp_hdr.msg_id = 20;
+    tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.token_len = 4;
+    tmp_hdr.token_ptr = (uint8_t*)malloc(4);
+    memset(tmp_hdr.token_ptr, '1', 4);
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    tmp_hdr.payload_ptr = NULL;
+    free(tmp_hdr.token_ptr);
+    tmp_hdr.token_ptr = NULL;
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+    retCounter = 6;
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL != ret );
+    CHECK( COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status );
+    free(payload);
+    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
+    sn_coap_protocol_destroy(handle);
+
+    // sn_coap_handle_blockwise_message - (recv block2) failed to allocate packet!
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+    sn_coap_parser_stub.expectedHeader->msg_id = 20;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0x08;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
+    payload = (uint8_t*)malloc(17);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 17;
+    sn_coap_parser_stub.expectedHeader->token_len = 4;
+    sn_coap_parser_stub.expectedHeader->token_ptr = (uint8_t*)malloc(4);
+    memset(sn_coap_parser_stub.expectedHeader->token_ptr, '1', 4);
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+
+    tmp_hdr.msg_id = 20;
+    tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.token_len = 4;
+    tmp_hdr.token_ptr = (uint8_t*)malloc(4);
+    memset(tmp_hdr.token_ptr, '1', 4);
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    tmp_hdr.payload_ptr = NULL;
+    free(tmp_hdr.token_ptr);
+    tmp_hdr.token_ptr = NULL;
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+    retCounter = 5;
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
     free(payload);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
@@ -1888,8 +2038,9 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     CHECK( NULL != ret );
     free(payload);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, ret);
-
     sn_coap_protocol_destroy(handle);
+
+    //  sn_coap_handle_blockwise_message - (send block2) failed to allocate options
     retCounter = 1;
     handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
@@ -1935,12 +2086,376 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     free(dst_packet_data_ptr);
 
     sn_coap_builder_stub.expectedInt16 = 1;
-    retCounter = 10;
+    retCounter = 7;
+    sn_coap_protocol_set_retransmission_buffer(handle,0,0);
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
+    free(payload);
+    sn_coap_parser_release_allocated_coap_msg_mem(handle, ret);
+
+    sn_coap_protocol_destroy(handle);
+
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0xc8c8c8;
+    sn_coap_parser_stub.expectedHeader->msg_id = 47;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    payload = (uint8_t*)malloc(5);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 5;
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr->block2 = 1;
+    tmp_hdr.msg_id = 47;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_len = buff_len;
+    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_len = buff_len;
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    free(tmp_hdr.uri_path_ptr);
+    free(tmp_hdr.token_ptr);
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+    sn_coap_builder_stub.expectedInt16 = 1;
+    retCounter = 12;
     sn_coap_protocol_set_retransmission_buffer(handle,2,1);
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL != ret );
     free(payload);
     sn_coap_parser_release_allocated_coap_msg_mem(handle, ret);
+    sn_coap_protocol_destroy(handle);
+
+    // sn_coap_handle_blockwise_message - failed to allocate for uri path ptr!
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0xc8c8c8;
+    sn_coap_parser_stub.expectedHeader->msg_id = 47;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    payload = (uint8_t*)malloc(5);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 5;
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr->block2 = 1;
+    tmp_hdr.msg_id = 47;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_len = buff_len;
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    free(tmp_hdr.uri_path_ptr);
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+    sn_coap_builder_stub.expectedInt16 = 1;
+    retCounter = 8;
+    sn_coap_protocol_set_retransmission_buffer(handle,2,1);
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
+    free(payload);
+    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
+    sn_coap_protocol_destroy(handle);
+
+    // sn_coap_handle_blockwise_message - failed to allocate for token ptr!
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0xc8c8c8;
+    sn_coap_parser_stub.expectedHeader->msg_id = 47;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    payload = (uint8_t*)malloc(5);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 5;
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr->block2 = 1;
+    tmp_hdr.msg_id = 47;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_len = buff_len;
+    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_len = buff_len;
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    free(tmp_hdr.uri_path_ptr);
+    free(tmp_hdr.token_ptr);
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+    sn_coap_builder_stub.expectedInt16 = 1;
+    retCounter = 9;
+    sn_coap_protocol_set_retransmission_buffer(handle,2,1);
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
+    free(payload);
+    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
+    sn_coap_protocol_destroy(handle);
+
+    // sn_coap_handle_blockwise_message - (send block2) failed to allocate packet!
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0xc8c8c8;
+    sn_coap_parser_stub.expectedHeader->msg_id = 47;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    payload = (uint8_t*)malloc(5);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 5;
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr->block2 = 1;
+    tmp_hdr.msg_id = 47;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_len = buff_len;
+    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_len = buff_len;
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    free(tmp_hdr.uri_path_ptr);
+    free(tmp_hdr.token_ptr);
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+    sn_coap_builder_stub.expectedInt16 = 1;
+    retCounter = 10;
+    sn_coap_protocol_set_retransmission_buffer(handle,2,1);
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
+    free(payload);
+
+    sn_coap_protocol_destroy(handle);
+
+    // sn_coap_handle_blockwise_message - (send block2) builder failed!
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0xc8c8c8;
+    sn_coap_parser_stub.expectedHeader->msg_id = 47;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    payload = (uint8_t*)malloc(5);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 5;
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr->block2 = 1;
+    tmp_hdr.msg_id = 47;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_len = buff_len;
+    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_len = buff_len;
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    free(tmp_hdr.uri_path_ptr);
+    free(tmp_hdr.token_ptr);
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+
+    sn_coap_builder_stub.expectedInt16 = -1;
+    retCounter = 11;
+    sn_coap_protocol_set_retransmission_buffer(handle,2,1);
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
+    free(payload);
+    sn_coap_builder_stub.expectedInt16 = 1;
+
+    sn_coap_protocol_destroy(handle);
+
+    // sn_coap_handle_blockwise_message - (send block2) failed to allocate blockwise message!
+    retCounter = 1;
+    handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+
+    sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
+    memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+
+    list = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(list, 0, sizeof(sn_coap_options_list_s));
+    sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = -1;
+    sn_coap_parser_stub.expectedHeader->options_list_ptr->block2 = 0xc8c8c8;
+    sn_coap_parser_stub.expectedHeader->msg_id = 47;
+    sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
+    payload = (uint8_t*)malloc(5);
+    sn_coap_parser_stub.expectedHeader->payload_ptr = payload;
+    sn_coap_parser_stub.expectedHeader->payload_len = 5;
+
+    memset(&tmp_addr, 0, sizeof(sn_nsdl_addr_s));
+    memset(&tmp_hdr, 0, sizeof(sn_coap_hdr_s));
+
+    dst_packet_data_ptr = (uint8_t*)malloc(5);
+    memset(dst_packet_data_ptr, '1', 5);
+
+    tmp_addr.addr_ptr = (uint8_t*)malloc(5);
+    memset(tmp_addr.addr_ptr, '1', 5);
+
+    retCounter = 20;
+    sn_coap_builder_stub.expectedInt16 = 1;
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
+    memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
+    tmp_hdr.options_list_ptr->block2 = 1;
+    tmp_hdr.msg_id = 47;
+    tmp_hdr.payload_len = buff_len;
+    tmp_hdr.uri_path_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.uri_path_len = buff_len;
+    tmp_hdr.token_ptr = (uint8_t*)malloc(buff_len);
+    tmp_hdr.token_len = buff_len;
+    sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
+
+    free(tmp_hdr.options_list_ptr);
+    free(tmp_hdr.payload_ptr);
+    free(tmp_hdr.uri_path_ptr);
+    free(tmp_hdr.token_ptr);
+    free(tmp_addr.addr_ptr);
+    free(dst_packet_data_ptr);
+
+    retCounter = 11;
+    sn_coap_protocol_set_retransmission_buffer(handle,2,1);
+    ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
+    CHECK( NULL == ret );
+    free(payload);
+
+
+
+
+
+
+
 
     // <-- block2 == 0x08
 


### PR DESCRIPTION
When request is sent, response can have blockwise option set. All requests must
be stored to the linked list.

Use token value for identify blockwise message transactions.

Compiler warning fixed - renamed message_id to msg_id. (‘message_id’ shadows
a global declaration)