### PR TITLE
Added own flag for enabling blockwise support

### DIFF
--- a/mbed-coap/sn_coap_protocol.h
+++ b/mbed-coap/sn_coap_protocol.h
@@ -268,6 +268,15 @@ extern void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle
  */
 extern void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param);
 
+/**
+ * \fn uint16_t sn_coap_protocol_get_configured_blockwise_size(struct coap_s *handle)
+ *
+ * \brief Get configured CoAP payload blockwise size
+ *
+ * \param *handle Pointer to CoAP library handle
+ */
+extern uint16_t sn_coap_protocol_get_configured_blockwise_size(struct coap_s *handle);
+
 #endif /* SN_COAP_PROTOCOL_H_ */
 
 #ifdef __cplusplus

--- a/mbed-coap/sn_config.h
+++ b/mbed-coap/sn_config.h
@@ -39,7 +39,8 @@
  *
  * \brief For Message blockwising
  * Init value for the maximum payload size to be sent and received at one blockwise message
- * Setting of this value to 0 will disable this feature, and also reduce use of ROM memory
+ * Setting of this value to 0 with SN_COAP_BLOCKWISE_ENABLED will disable this feature, and
+ * also reduce use of ROM memory.
  * Note: This define is common for both received and sent Blockwise messages
  */
 #undef SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE   /* 0 */ // < Must be 2^x and x is at least 4. Suitable values: 0, 16, 32, 64, 128, 256, 512 and 1024
@@ -106,6 +107,13 @@
  * Note that value has no effect if blockwise transfer is disabled.
  */
 #undef SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE        /* 0 */
+
+/**
+ * \def SN_COAP_BLOCKWISE_ENABLED
+ * \brief Enables the blockwise functionality in CoAP library also when blockwise payload
+ * size is set to '0' in  SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE.
+ */
+#undef SN_COAP_BLOCKWISE_ENABLED                    /* 0 */
 
 #ifdef MBED_CLIENT_USER_CONFIG_FILE
 #include MBED_CLIENT_USER_CONFIG_FILE

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -113,6 +113,10 @@ struct sn_coap_hdr_;
 #define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE MBED_CONF_MBED_CLIENT_SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 #endif
 
+#ifndef SN_COAP_BLOCKWISE_ENABLED
+#define SN_COAP_BLOCKWISE_ENABLED                   0  /**< Enable blockwise */
+#endif
+
 #ifndef SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 #define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE          0  /**< Must be 2^x and x is at least 4. Suitable values: 0, 16, 32, 64, 128, 256, 512 and 1024 */
 #endif
@@ -145,9 +149,7 @@ struct sn_coap_hdr_;
 #define COAP_OPTION_BLOCK_NONE                      (-1) /**< Internal value to represent no Block1/2 option */
 
 
-#if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not used at all, this part of code will not be compiled */
 int8_t prepare_blockwise_message(struct coap_s *handle, struct sn_coap_hdr_ *coap_hdr_ptr);
-#endif
 
 /* Structure which is stored to Linked list for message sending purposes */
 typedef struct coap_send_msg_ {
@@ -230,7 +232,7 @@ struct coap_s {
         uint16_t                      count_duplication_msgs;
     #endif
 
-    #if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwise is not used at all, this part of code will not be compiled */
+    #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwise is not enabled, this part of code will not be compiled */
         coap_blockwise_msg_list_t     linked_list_blockwise_sent_msgs; /* Blockwise message to to be sent is stored to this Linked list */
         coap_blockwise_payload_list_t linked_list_blockwise_received_payloads; /* Blockwise payload to to be received is stored to this Linked list */
     #endif

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -340,7 +340,7 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
                 returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_coap_msg_ptr->options_list_ptr->size2, COAP_OPTION_SIZE2, &tempInt);
             }
         }
-#if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+#if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
         if ((src_coap_msg_ptr->payload_len > SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE) &&
             (src_coap_msg_ptr->payload_len > blockwise_payload_size) &&
             (blockwise_payload_size > 0)) {

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -2978,3 +2978,11 @@ TEST(libCoap_protocol, sn_coap_protocol_handle_block2_response_internally)
     sn_coap_protocol_destroy(handle);
 }
 
+TEST(libCoap_protocol, sn_coap_protocol_get_configured_blockwise_size)
+{
+    retCounter = 9;
+    struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
+    CHECK(sn_coap_protocol_get_configured_blockwise_size(handle) == YOTTA_CFG_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE);
+    sn_coap_protocol_destroy(handle);
+}
+


### PR DESCRIPTION
Added own flag to enable blockwise support, without setting default blockwise
payload size. This allows to receive blockwise messages while still sending
without blockwise.