### PR TITLE
Copy block2 into request from sent_blockwise ptr

### DIFF
--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -1796,7 +1796,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                     if (src_coap_blockwise_ack_msg_ptr->options_list_ptr) {
                         src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1 = COAP_OPTION_BLOCK_NONE;
-                        src_coap_blockwise_ack_msg_ptr->options_list_ptr->block2 = COAP_OPTION_BLOCK_NONE;
+                        // Do not clear block2 as it might have been set in the original request to request
+                        // specific size blocks
                     } else {
                         if (!sn_coap_parser_alloc_options(handle, src_coap_blockwise_ack_msg_ptr)) {
                             tr_error("sn_coap_handle_blockwise_message - (send block1) failed to allocate ack message!");
@@ -1823,6 +1824,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         src_coap_blockwise_ack_msg_ptr->payload_len = block_size;
                         src_coap_blockwise_ack_msg_ptr->payload_ptr = src_coap_blockwise_ack_msg_ptr->payload_ptr + (block_size * block_number);
                     }
+
                     /* Build and send block message */
                     dst_packed_data_needed_mem = sn_coap_builder_calc_needed_packet_data_size_2(src_coap_blockwise_ack_msg_ptr, handle->sn_coap_block_data_size);
 
@@ -2245,7 +2247,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                 if (src_coap_blockwise_ack_msg_ptr->options_list_ptr) {
                     src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1 = COAP_OPTION_BLOCK_NONE;
-                    src_coap_blockwise_ack_msg_ptr->options_list_ptr->block2 = COAP_OPTION_BLOCK_NONE;
+                    // Do not clear block2 as it might have been set in the original request to request
+                    // specific size blocks
                 } else {
                     if (sn_coap_parser_alloc_options(handle, src_coap_blockwise_ack_msg_ptr) == NULL) {
                         tr_error("sn_coap_handle_blockwise_message - (recv block2) failed to allocate options!");


### PR DESCRIPTION
When sending a request with block2 option, eg. indicating need
for response to be blockwised, do not clear the block2 option when
sending next request. This fixes an issue where previously the block2
was only sent for the first blockwise request and not for the
subsequent ones, including the last request. This made the response
not follow the request block2 option.