### PR TITLE
Add function to clear received blockwise messages

### DIFF
--- a/mbed-coap/sn_coap_protocol.h
+++ b/mbed-coap/sn_coap_protocol.h
@@ -269,6 +269,15 @@ extern int8_t sn_coap_protocol_handle_block2_response_internally(struct coap_s *
 extern void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle);
 
 /**
+ * \fn void sn_coap_protocol_clear_received_blockwise_messages(struct coap_s *handle)
+ *
+ * \brief This function clears all the received blockwise messages from the linked list.
+ *
+ * \param *handle Pointer to CoAP library handle
+ */
+extern void sn_coap_protocol_clear_received_blockwise_messages(struct coap_s *handle);
+
+/**
  * \fn void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param)
  *
  * \brief This function sends a RESET message.

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -257,6 +257,21 @@ void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle)
 #endif
 }
 
+void sn_coap_protocol_clear_received_blockwise_messages(struct coap_s *handle)
+{
+    (void) handle;
+#if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+    if (handle == NULL) {
+        return;
+    }
+
+    /* Loop all stored Blockwise messages in Linked list */
+    ns_list_foreach_safe(coap_blockwise_payload_s, removed_blockwise_payload_ptr, &handle->linked_list_blockwise_received_payloads) {
+        sn_coap_protocol_linked_list_blockwise_payload_remove(handle, removed_blockwise_payload_ptr);
+    }
+#endif
+}
+
 int8_t sn_coap_protocol_set_duplicate_buffer_size(struct coap_s *handle, uint8_t message_count)
 {
     (void) handle;


### PR DESCRIPTION
Add function that can be used to clear the received
blockwise payloads for example in the case of a
connection error.