### PR TITLE
Fix handling of duplicate blockwise ACK's

### DIFF
--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -917,8 +917,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     retCounter = 10;
     sn_coap_protocol_set_block_size(handle, 1024);
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
-    CHECK( NULL != ret );
-    CHECK(COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING == ret->coap_status);
+    CHECK( NULL == ret );
     free(payload);
     free(list);
     free(sn_coap_parser_stub.expectedHeader);


### PR DESCRIPTION
CoAP data buffer was not added into duplication info store when creating response for blockwise request.
This leads to case where whole bootstrap flow just timeouts if received any duplicate messages during blockwise operation.

Fixes error: IOTCLT-3188 - UDP connection fails for lost ACK sending