### PR TITLE
Do not remove stored (GET) blockwise message when EMPTY ACK received

### DIFF
--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -738,7 +738,10 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
             (returned_dst_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE ||
              returned_dst_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE)) {
         returned_dst_coap_msg_ptr = sn_coap_handle_blockwise_message(handle, src_addr_ptr, returned_dst_coap_msg_ptr, param);
-    } else {
+    } else if (returned_dst_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY) {
+        // Do not clean stored blockwise message when empty ack is received.
+        // Stored message is mandatory when building a next (GET) blockwise message.
+        // This will happen when non piggybacked response mode is selected.
         /* Get ... */
         coap_blockwise_msg_s *stored_blockwise_msg_temp_ptr = NULL;
 

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -2641,6 +2641,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 18;
 
@@ -2681,6 +2682,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_RESET;
     sn_coap_parser_stub.expectedHeader->msg_id = 18;
 
@@ -2726,6 +2728,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
+    sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
     sn_coap_parser_stub.expectedHeader->msg_id = 18;
 


### PR DESCRIPTION
When non piggybacked response mode is used original GET request must not be removed from the stored message list.
Message is needed for building the next (GET) blockwise message.