### PR TITLE
Mem opt part 3 final

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,4 +1,5 @@
 test/*
+test_modules/*
 unittest/*
 yotta_modules/*
 yotta_targets/*

--- a/.mbedignore
+++ b/.mbedignore
@@ -1,2 +1,4 @@
 test/*
 unittest/*
+yotta_modules/*
+yotta_targets/*

--- a/mbed-coap/sn_coap_header.h
+++ b/mbed-coap/sn_coap_header.h
@@ -436,6 +436,8 @@ extern sn_coap_hdr_s *sn_coap_parser_alloc_message(struct coap_s *handle);
  */
 extern sn_coap_options_list_s *sn_coap_parser_alloc_options(struct coap_s *handle, sn_coap_hdr_s *coap_msg_ptr);
 
+extern sn_coap_hdr_s *sn_coap_parser_alloc_message_with_options(struct coap_s *handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mbed-coap/sn_coap_header.h
+++ b/mbed-coap/sn_coap_header.h
@@ -338,7 +338,7 @@ extern void sn_coap_parser_release_allocated_coap_msg_mem(struct coap_s *handle,
  *          -1 = Failure in given CoAP header structure\n
  *          -2 = Failure in given pointer (= NULL)
  */
-extern int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr);
+extern int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr);
 
 /**
  * \fn uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_coap_msg_ptr)
@@ -351,7 +351,7 @@ extern int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_
  * \return Return value is count of needed memory as bytes for build Packet data
  *          Null if failed
  */
-extern uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_coap_msg_ptr);
+extern uint16_t sn_coap_builder_calc_needed_packet_data_size(const sn_coap_hdr_s *src_coap_msg_ptr);
 
 /**
  * \fn int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr,  uint16_t blockwise_size)
@@ -368,7 +368,7 @@ extern uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_
  *          -1 = Failure in given CoAP header structure\n
  *          -2 = Failure in given pointer (= NULL)
  */
-extern int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
+extern int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
 
 /**
  * \fn uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size)
@@ -382,7 +382,7 @@ extern int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *sr
  * \return Return value is count of needed memory as bytes for build Packet data
  *          Null if failed
  */
-extern uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
+extern uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size);
 
 /**
  * \fn sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
@@ -397,7 +397,7 @@ extern uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *sr
  *          NULL    Error in parsing the request
  *
  */
-extern sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code);
+extern sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, const sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code);
 
 /**
  * \brief Initialise a message structure to empty

--- a/mbed-coap/sn_coap_protocol.h
+++ b/mbed-coap/sn_coap_protocol.h
@@ -235,7 +235,7 @@ extern int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint
  *
  * \brief If re-transmissions are enabled, this function removes message from retransmission buffer.
  */
-extern int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, uint8_t *token, uint8_t token_len);
+extern int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, const uint8_t *token, uint8_t token_len);
 
 /**
  * \fn int8_t sn_coap_convert_block_size(uint16_t block_size)

--- a/mbed-coap/sn_coap_protocol.h
+++ b/mbed-coap/sn_coap_protocol.h
@@ -38,7 +38,8 @@ extern "C" {
  *
  * \param *used_malloc_func_ptr is function pointer for used memory allocation function.
  *
- * \param *used_free_func_ptr is function pointer for used memory free function.
+ * \param *used_free_func_ptr is function pointer for used memory free function. Note: the implementation
+ *          must handle NULL parameter and ignore it just as typical libc's free() does.
  *
  * \param *used_tx_callback_ptr function callback pointer to tx function for sending coap messages
  *

--- a/mbed-coap/sn_config.h
+++ b/mbed-coap/sn_config.h
@@ -250,4 +250,14 @@
 #define SN_COAP_MAX_INCOMING_BLOCK_MESSAGE_SIZE     UINT16_MAX
 #endif
 
+/**
+ * \def SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED
+ * \brief A size optimization switch, which removes the blockwise Block2 response if set to 0.
+ * handling code which is typically overridden by a call of "sn_coap_protocol_handle_block2_response_internally(coap, false);".
+ * By default the code is there, so the override can be reversed by "sn_coap_protocol_handle_block2_response_internally(coap, true)".
+ */
+#ifndef SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED
+#define SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED  1
+#endif
+
 #endif // SN_CONFIG_H

--- a/source/include/sn_coap_header_internal.h
+++ b/source/include/sn_coap_header_internal.h
@@ -69,7 +69,7 @@ typedef struct sn_nsdl_transmit_ {
 /* * * * * * * * * * * * * * * * * * * * * * */
 /* * * * EXTERNAL FUNCTION PROTOTYPES  * * * */
 /* * * * * * * * * * * * * * * * * * * * * * */
-extern int8_t           sn_coap_header_validity_check(sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version);
+extern int8_t           sn_coap_header_validity_check(const sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version);
 
 #endif /* SN_COAP_HEADER_INTERNAL_H_ */
 

--- a/source/include/sn_coap_header_internal.h
+++ b/source/include/sn_coap_header_internal.h
@@ -58,7 +58,7 @@ extern "C" {
  * \brief This structure is returned by sn_coap_exec() for sending
  */
 typedef struct sn_nsdl_transmit_ {
-    sn_nsdl_addr_s         *dst_addr_ptr;
+    sn_nsdl_addr_s          dst_addr_ptr;
 
     sn_nsdl_capab_e         protocol;
 

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -139,6 +139,12 @@ struct coap_s {
     uint8_t sn_coap_internal_block2_resp_handling; /* If this is set then coap itself sends a next GET request automatically */
 };
 
+/* Utility function which performs a call to sn_coap_protocol_malloc() and memset's the result to zero. */
+void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length);
+
+/* Utility function which performs a call to sn_coap_protocol_malloc() and memcopy's the source to result buffer. */
+void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint16_t length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -48,7 +48,7 @@ typedef struct coap_send_msg_ {
     uint8_t             resending_counter;  /* Tells how many times message is still tried to resend */
     uint32_t            resending_time;     /* Tells next resending time */
 
-    sn_nsdl_transmit_s *send_msg_ptr;
+    sn_nsdl_transmit_s  send_msg_ptr;
 
     struct coap_s       *coap;              /* CoAP library handle */
     void                *param;             /* Extra parameter that will be passed to TX/RX callback functions */

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -50,7 +50,6 @@ typedef struct coap_send_msg_ {
 
     sn_nsdl_transmit_s  send_msg_ptr;
 
-    struct coap_s       *coap;              /* CoAP library handle */
     void                *param;             /* Extra parameter that will be passed to TX/RX callback functions */
 
     ns_list_link_t      link;
@@ -64,7 +63,6 @@ typedef struct coap_duplication_info_ {
     uint16_t            msg_id;
     uint16_t            packet_len;
     uint8_t             *packet_ptr;
-    struct coap_s       *coap;  /* CoAP library handle */
     sn_nsdl_addr_s      *address;
     void                *param;
     ns_list_link_t      link;
@@ -77,7 +75,6 @@ typedef struct coap_blockwise_msg_ {
     uint32_t            timestamp;  /* Tells when Blockwise message is stored to Linked list */
 
     sn_coap_hdr_s       *coap_msg_ptr;
-    struct coap_s       *coap;      /* CoAP library handle */
 
     void                *param;
     uint16_t            msg_id;
@@ -100,7 +97,6 @@ typedef struct coap_blockwise_payload_ {
 
     uint16_t            payload_len;
     uint8_t             *payload_ptr;
-    struct coap_s       *coap;  /* CoAP library handle */
 
     ns_list_link_t     link;
 } coap_blockwise_payload_s;

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -203,30 +203,33 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
         }
         /* If options list pointer exists */
         if (src_coap_msg_ptr->options_list_ptr != NULL) {
+
+            const sn_coap_options_list_s *src_options_list_ptr = src_coap_msg_ptr->options_list_ptr;
+
             /* ACCEPT - An integer option, up to 2 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->accept != COAP_CT_NONE) {
-                if ((uint32_t) src_coap_msg_ptr->options_list_ptr->accept > 0xffff) {
+            if (src_options_list_ptr->accept != COAP_CT_NONE) {
+                if ((uint32_t) src_options_list_ptr->accept > 0xffff) {
                     tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - accept too large!");
                     return 0;
                 }
 
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_coap_msg_ptr->options_list_ptr->accept, COAP_OPTION_ACCEPT, &tempInt);
+                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->accept, COAP_OPTION_ACCEPT, &tempInt);
             }
             /* MAX AGE - An integer option, omitted for default. Up to 4 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_coap_msg_ptr->options_list_ptr->max_age, COAP_OPTION_MAX_AGE, &tempInt);
+            if (src_options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
+                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->max_age, COAP_OPTION_MAX_AGE, &tempInt);
             }
             /* PROXY URI - Length of this option is  1-1034 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->proxy_uri_ptr != NULL) {
-                if (src_coap_msg_ptr->options_list_ptr->proxy_uri_len >= 1 && src_coap_msg_ptr->options_list_ptr->proxy_uri_len <= 12) {            /* Add option header byte(s) - depending of option length */
+            if (src_options_list_ptr->proxy_uri_ptr != NULL) {
+                if (src_options_list_ptr->proxy_uri_len >= 1 && src_options_list_ptr->proxy_uri_len <= 12) {            /* Add option header byte(s) - depending of option length */
                     returned_byte_count++;
                 }
 
-                else if (src_coap_msg_ptr->options_list_ptr->proxy_uri_len >= 13 && src_coap_msg_ptr->options_list_ptr->proxy_uri_len <= 269) {
+                else if (src_options_list_ptr->proxy_uri_len >= 13 && src_options_list_ptr->proxy_uri_len <= 269) {
                     returned_byte_count += 2;
                 }
 
-                else if (src_coap_msg_ptr->options_list_ptr->proxy_uri_len >= 270 && src_coap_msg_ptr->options_list_ptr->proxy_uri_len <= 1034) {
+                else if (src_options_list_ptr->proxy_uri_len >= 270 && src_options_list_ptr->proxy_uri_len <= 1034) {
                     returned_byte_count += 3;
                 }
 
@@ -236,12 +239,12 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
                 }
 
                 /* Add needed memory for Option value */
-                returned_byte_count += src_coap_msg_ptr->options_list_ptr->proxy_uri_len;
+                returned_byte_count += src_options_list_ptr->proxy_uri_len;
             }
             /* ETAG - Repeatable option. Length of this option is 1-8 bytes*/
-            if (src_coap_msg_ptr->options_list_ptr->etag_ptr != NULL) {
-                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_coap_msg_ptr->options_list_ptr->etag_len,
-                                         src_coap_msg_ptr->options_list_ptr->etag_ptr, COAP_OPTION_ETAG);
+            if (src_options_list_ptr->etag_ptr != NULL) {
+                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_options_list_ptr->etag_len,
+                                         src_options_list_ptr->etag_ptr, COAP_OPTION_ETAG);
                 if (repeatable_option_size) {
                     returned_byte_count += repeatable_option_size;
                 } else {
@@ -250,12 +253,12 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
                 }
             }
             /* URI HOST - Length of this option is 1-255 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->uri_host_ptr != NULL) {
-                if (src_coap_msg_ptr->options_list_ptr->uri_host_len > 0 && src_coap_msg_ptr->options_list_ptr->uri_host_len <= 12) {
+            if (src_options_list_ptr->uri_host_ptr != NULL) {
+                if (src_options_list_ptr->uri_host_len > 0 && src_options_list_ptr->uri_host_len <= 12) {
                     returned_byte_count++;
                 }
 
-                else if (src_coap_msg_ptr->options_list_ptr->uri_host_len >= 13 && src_coap_msg_ptr->options_list_ptr->uri_host_len <= 255) {
+                else if (src_options_list_ptr->uri_host_len >= 13 && src_options_list_ptr->uri_host_len <= 255) {
                     returned_byte_count += 2;
                 }
 
@@ -264,12 +267,12 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
                     return 0;
                 }
 
-                returned_byte_count += src_coap_msg_ptr->options_list_ptr->uri_host_len;
+                returned_byte_count += src_options_list_ptr->uri_host_len;
             }
             /* LOCATION PATH - Repeatable option. Length of this option is 0-255 bytes*/
-            if (src_coap_msg_ptr->options_list_ptr->location_path_ptr != NULL) {
-                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_coap_msg_ptr->options_list_ptr->location_path_len,
-                                         src_coap_msg_ptr->options_list_ptr->location_path_ptr, COAP_OPTION_LOCATION_PATH);
+            if (src_options_list_ptr->location_path_ptr != NULL) {
+                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_options_list_ptr->location_path_len,
+                                         src_options_list_ptr->location_path_ptr, COAP_OPTION_LOCATION_PATH);
                 if (repeatable_option_size) {
                     returned_byte_count += repeatable_option_size;
                 } else {
@@ -278,17 +281,17 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
                 }
             }
             /* URI PORT - An integer option, up to 2 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
-                if ((uint32_t) src_coap_msg_ptr->options_list_ptr->uri_port > 0xffff) {
+            if (src_options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
+                if ((uint32_t) src_options_list_ptr->uri_port > 0xffff) {
                     tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - uri port too large!");
                     return 0;
                 }
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_coap_msg_ptr->options_list_ptr->uri_port, COAP_OPTION_URI_PORT, &tempInt);
+                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->uri_port, COAP_OPTION_URI_PORT, &tempInt);
             }
             /* lOCATION QUERY - Repeatable option. Length of this option is 0-255 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->location_query_ptr != NULL) {
-                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_coap_msg_ptr->options_list_ptr->location_query_len,
-                                         src_coap_msg_ptr->options_list_ptr->location_query_ptr, COAP_OPTION_LOCATION_QUERY);
+            if (src_options_list_ptr->location_query_ptr != NULL) {
+                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_options_list_ptr->location_query_len,
+                                         src_options_list_ptr->location_query_ptr, COAP_OPTION_LOCATION_QUERY);
                 if (repeatable_option_size) {
                     returned_byte_count += repeatable_option_size;
                 } else {
@@ -297,16 +300,16 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
                 }
             }
             /* OBSERVE - An integer option, up to 3 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
-                if ((uint32_t) src_coap_msg_ptr->options_list_ptr->observe > 0xffffff) {
+            if (src_options_list_ptr->observe != COAP_OBSERVE_NONE) {
+                if ((uint32_t) src_options_list_ptr->observe > 0xffffff) {
                     return 0;
                 }
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_coap_msg_ptr->options_list_ptr->observe, COAP_OPTION_OBSERVE, &tempInt);
+                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->observe, COAP_OPTION_OBSERVE, &tempInt);
             }
             /* URI QUERY - Repeatable option. Length of this option is 1-255 */
-            if (src_coap_msg_ptr->options_list_ptr->uri_query_ptr != NULL) {
-                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_coap_msg_ptr->options_list_ptr->uri_query_len,
-                                         src_coap_msg_ptr->options_list_ptr->uri_query_ptr, COAP_OPTION_URI_QUERY);
+            if (src_options_list_ptr->uri_query_ptr != NULL) {
+                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_options_list_ptr->uri_query_len,
+                                         src_options_list_ptr->uri_query_ptr, COAP_OPTION_URI_QUERY);
                 if (repeatable_option_size) {
                     returned_byte_count += repeatable_option_size;
                 } else {
@@ -316,8 +319,8 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
             }
 
             /* BLOCK 1 - An integer option, up to 3 bytes */
-            if (src_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE) {
-                if ((uint32_t) src_coap_msg_ptr->options_list_ptr->block1 > 0xffffff) {
+            if (src_options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE) {
+                if ((uint32_t) src_options_list_ptr->block1 > 0xffffff) {
                     tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - block1 too large!");
                     return 0;
                 }
@@ -375,38 +378,42 @@ static uint8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *
     uint8_t previous_option_number = 0;
     uint8_t needed_space           = 0;
 
-    if (src_coap_msg_ptr->options_list_ptr != NULL) {
+    const sn_coap_options_list_s* options_list_ptr = src_coap_msg_ptr->options_list_ptr;
+
+    if (options_list_ptr != NULL) {
+
+
         /* If option numbers greater than 12 is not used, then jumping is not needed */
         //TODO: Check if this is really needed! Does it enhance perf? If not -> remove
-        if (!src_coap_msg_ptr->options_list_ptr->uri_query_ptr       &&
-                src_coap_msg_ptr->options_list_ptr->accept == COAP_CT_NONE &&
-                !src_coap_msg_ptr->options_list_ptr->location_query_ptr &&
-                src_coap_msg_ptr->options_list_ptr->block2 == COAP_OPTION_BLOCK_NONE &&
-                src_coap_msg_ptr->options_list_ptr->block1 == COAP_OPTION_BLOCK_NONE &&
-                !src_coap_msg_ptr->options_list_ptr->proxy_uri_ptr      &&
-                src_coap_msg_ptr->options_list_ptr->max_age == COAP_OPTION_MAX_AGE_DEFAULT &&
-                !src_coap_msg_ptr->options_list_ptr->use_size1          &&
-                !src_coap_msg_ptr->options_list_ptr->use_size2) {
+        if (!options_list_ptr->uri_query_ptr       &&
+                options_list_ptr->accept == COAP_CT_NONE &&
+                !options_list_ptr->location_query_ptr &&
+                options_list_ptr->block2 == COAP_OPTION_BLOCK_NONE &&
+                options_list_ptr->block1 == COAP_OPTION_BLOCK_NONE &&
+                !options_list_ptr->proxy_uri_ptr      &&
+                options_list_ptr->max_age == COAP_OPTION_MAX_AGE_DEFAULT &&
+                !options_list_ptr->use_size1          &&
+                !options_list_ptr->use_size2) {
             return 0;
         }
 
-        if (src_coap_msg_ptr->options_list_ptr->uri_host_ptr != NULL) {
+        if (options_list_ptr->uri_host_ptr != NULL) {
             previous_option_number = (COAP_OPTION_URI_HOST);
         }
 
-        if (src_coap_msg_ptr->options_list_ptr->etag_ptr != NULL) {
+        if (options_list_ptr->etag_ptr != NULL) {
             previous_option_number = (COAP_OPTION_ETAG);
         }
 
-        if (src_coap_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
+        if (options_list_ptr->observe != COAP_OBSERVE_NONE) {
             previous_option_number = (COAP_OPTION_OBSERVE);
         }
 
-        if (src_coap_msg_ptr->options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
+        if (options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
             previous_option_number = (COAP_OPTION_URI_PORT);
         }
 
-        if (src_coap_msg_ptr->options_list_ptr->location_path_ptr != NULL) {
+        if (options_list_ptr->location_path_ptr != NULL) {
             previous_option_number = (COAP_OPTION_LOCATION_PATH);
         }
 
@@ -416,50 +423,51 @@ static uint8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *
         if (src_coap_msg_ptr->content_format != COAP_CT_NONE) {
             previous_option_number = (COAP_OPTION_CONTENT_FORMAT);
         }
-        if (src_coap_msg_ptr->options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
+
+        if (options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
             if ((COAP_OPTION_MAX_AGE - previous_option_number) > 12) {
                 needed_space += 1;
             }
             previous_option_number = (COAP_OPTION_MAX_AGE);
         }
 
-        if (src_coap_msg_ptr->options_list_ptr->uri_query_ptr != NULL) {
+        if (options_list_ptr->uri_query_ptr != NULL) {
             if ((COAP_OPTION_URI_QUERY - previous_option_number) > 12) {
                 needed_space += 1;
             }
             previous_option_number = (COAP_OPTION_URI_QUERY);
         }
-        if (src_coap_msg_ptr->options_list_ptr->accept != COAP_CT_NONE) {
+        if (options_list_ptr->accept != COAP_CT_NONE) {
             if ((COAP_OPTION_ACCEPT - previous_option_number) > 12) {
                 needed_space += 1;
             }
             previous_option_number = (COAP_OPTION_ACCEPT);
         }
-        if (src_coap_msg_ptr->options_list_ptr->location_query_ptr != NULL) {
+        if (options_list_ptr->location_query_ptr != NULL) {
             if ((COAP_OPTION_LOCATION_QUERY - previous_option_number) > 12) {
                 needed_space += 1;
             }
             previous_option_number = (COAP_OPTION_LOCATION_QUERY);
         }
-        if (src_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE) {
+        if (options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE) {
             if ((COAP_OPTION_BLOCK2 - previous_option_number) > 12 ){
                 needed_space += 1;
             }
             previous_option_number = (COAP_OPTION_BLOCK2);
         }
-        if (src_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE) {
+        if (options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE) {
             if ((COAP_OPTION_BLOCK1 - previous_option_number) > 12 ){
                 needed_space += 1;
             }
             previous_option_number = (COAP_OPTION_BLOCK1);
         }
-        if (src_coap_msg_ptr->options_list_ptr->use_size2) {
+        if (options_list_ptr->use_size2) {
             if ((COAP_OPTION_SIZE2 - previous_option_number) > 12) {
                 needed_space += 1;
             }
             previous_option_number = (COAP_OPTION_SIZE2);
         }
-        if (src_coap_msg_ptr->options_list_ptr->proxy_uri_ptr != NULL) {
+        if (options_list_ptr->proxy_uri_ptr != NULL) {
             if ((COAP_OPTION_PROXY_URI - previous_option_number) > 12) {
                 needed_space += 1;
             }
@@ -468,7 +476,7 @@ static uint8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *
             }
             previous_option_number = (COAP_OPTION_PROXY_URI);
         }
-        if (src_coap_msg_ptr->options_list_ptr->use_size1 ) {
+        if (options_list_ptr->use_size1 ) {
             if ((COAP_OPTION_SIZE1 - previous_option_number) > 12) {
                 needed_space += 1;
             }
@@ -507,8 +515,8 @@ static int8_t sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, const
         return -1;
     }
 
-    /* * * Add CoAP Version * * */
-    **dst_packet_data_pptr += COAP_VERSION;
+    /* * * Set CoAP Version * * */
+    **dst_packet_data_pptr = COAP_VERSION;
 
     /* * * Add Message type * * */
     **dst_packet_data_pptr += src_coap_msg_ptr->msg_type;
@@ -567,31 +575,33 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, cons
 
     //missing: COAP_OPTION_IF_MATCH, COAP_OPTION_IF_NONE_MATCH, COAP_OPTION_SIZE
 
+    const sn_coap_options_list_s *src_options_list_ptr = src_coap_msg_ptr->options_list_ptr;
+
     /* Check if less used options are used at all */
-    if (src_coap_msg_ptr->options_list_ptr != NULL) {
+    if (src_options_list_ptr != NULL) {
         /* * * * Build Uri-Host option * * * */
-        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->uri_host_len,
-                     src_coap_msg_ptr->options_list_ptr->uri_host_ptr, COAP_OPTION_URI_HOST, &previous_option_number);
+        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, src_options_list_ptr->uri_host_len,
+                     src_options_list_ptr->uri_host_ptr, COAP_OPTION_URI_HOST, &previous_option_number);
 
         /* * * * Build ETag option  * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->etag_ptr,
-                     src_coap_msg_ptr->options_list_ptr->etag_len, COAP_OPTION_ETAG, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->etag_ptr,
+                     src_options_list_ptr->etag_len, COAP_OPTION_ETAG, &previous_option_number);
 
         /* * * * Build Observe option  * * * * */
-        if (src_coap_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->observe,
+        if (src_options_list_ptr->observe != COAP_OBSERVE_NONE) {
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->observe,
                          COAP_OPTION_OBSERVE, &previous_option_number);
         }
 
         /* * * * Build Uri-Port option * * * */
-        if (src_coap_msg_ptr->options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->uri_port,
+        if (src_options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->uri_port,
                          COAP_OPTION_URI_PORT, &previous_option_number);
         }
 
         /* * * * Build Location-Path option  * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->location_path_ptr,
-                     src_coap_msg_ptr->options_list_ptr->location_path_len, COAP_OPTION_LOCATION_PATH, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->location_path_ptr,
+                     src_options_list_ptr->location_path_len, COAP_OPTION_LOCATION_PATH, &previous_option_number);
     }
     /* * * * Build Uri-Path option * * * */
     sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->uri_path_ptr,
@@ -603,55 +613,53 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, cons
                      COAP_OPTION_CONTENT_FORMAT, &previous_option_number);
     }
 
-    if (src_coap_msg_ptr->options_list_ptr != NULL) {
+    if (src_options_list_ptr != NULL) {
         /* * * * Build Max-Age option  * * * */
-        if (src_coap_msg_ptr->options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->max_age,
+        if (src_options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->max_age,
                          COAP_OPTION_MAX_AGE, &previous_option_number);
         }
 
         /* * * * Build Uri-Query option  * * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->uri_query_ptr,
-                     src_coap_msg_ptr->options_list_ptr->uri_query_len, COAP_OPTION_URI_QUERY, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->uri_query_ptr,
+                     src_options_list_ptr->uri_query_len, COAP_OPTION_URI_QUERY, &previous_option_number);
 
         /* * * * Build Accept option  * * * * */
         if (src_coap_msg_ptr->options_list_ptr->accept != COAP_CT_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->accept,
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->accept,
                          COAP_OPTION_ACCEPT, &previous_option_number);
         }
-    }
 
-    if (src_coap_msg_ptr->options_list_ptr != NULL) {
         /* * * * Build Location-Query option * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->location_query_ptr,
-                     src_coap_msg_ptr->options_list_ptr->location_query_len, COAP_OPTION_LOCATION_QUERY, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->location_query_ptr,
+                     src_options_list_ptr->location_query_len, COAP_OPTION_LOCATION_QUERY, &previous_option_number);
 
         /* * * * Build Block2 option * * * * */
         if (src_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->block2,
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->block2,
                          COAP_OPTION_BLOCK2, &previous_option_number);
         }
 
         /* * * * Build Block1 option * * * * */
         if (src_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->block1,
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->block1,
                          COAP_OPTION_BLOCK1, &previous_option_number);
         }
 
         /* * * * Build Size2 option * * * */
         if (src_coap_msg_ptr->options_list_ptr->use_size2) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->size2,
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->size2,
                          COAP_OPTION_SIZE2, &previous_option_number);
         }
 
         /* * * * Build Proxy-Uri option * * * */
-        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->proxy_uri_len,
-                     src_coap_msg_ptr->options_list_ptr->proxy_uri_ptr, COAP_OPTION_PROXY_URI, &previous_option_number);
+        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, src_options_list_ptr->proxy_uri_len,
+                     src_options_list_ptr->proxy_uri_ptr, COAP_OPTION_PROXY_URI, &previous_option_number);
 
 
         /* * * * Build Size1 option * * * */
-        if (src_coap_msg_ptr->options_list_ptr->use_size1) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->size1,
+        if (src_options_list_ptr->use_size1) {
+            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->size1,
                          COAP_OPTION_SIZE1, &previous_option_number);
         }
     }

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -514,25 +514,19 @@ static int8_t sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, const
         return -1;
     }
 
-    /* * * Set CoAP Version * * */
-    **dst_packet_data_pptr = COAP_VERSION;
+    uint8_t* dest_packet = *dst_packet_data_pptr;
 
-    /* * * Add Message type * * */
-    **dst_packet_data_pptr += src_coap_msg_ptr->msg_type;
+    /* Set CoAP Version, Message type and Token length */
+    dest_packet[0] = COAP_VERSION | src_coap_msg_ptr->msg_type | src_coap_msg_ptr->token_len;
 
-    /* * * Add Token length * * */
-    **dst_packet_data_pptr += (src_coap_msg_ptr->token_len);
-
-    (*dst_packet_data_pptr) ++;
     /* * * Add Message code * * */
-    **dst_packet_data_pptr = src_coap_msg_ptr->msg_code;
-    (*dst_packet_data_pptr) ++;
+    dest_packet[1] = src_coap_msg_ptr->msg_code;
 
     /* * * Add Message ID * * */
-    **dst_packet_data_pptr = (uint8_t)(src_coap_msg_ptr->msg_id >> COAP_HEADER_MSG_ID_MSB_SHIFT); /* MSB part */
-    (*dst_packet_data_pptr) ++;
-    **dst_packet_data_pptr = (uint8_t)src_coap_msg_ptr->msg_id;                                   /* LSB part */
-    (*dst_packet_data_pptr) ++;
+    dest_packet[2] = (uint8_t)(src_coap_msg_ptr->msg_id >> COAP_HEADER_MSG_ID_MSB_SHIFT); /* MSB part */
+    dest_packet[3] = (uint8_t)src_coap_msg_ptr->msg_id;                                   /* LSB part */
+
+    *dst_packet_data_pptr = dest_packet + 4;
 
     /* Success */
     return 0;

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -86,13 +86,12 @@ sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap
 
     if (coap_packet_ptr->token_ptr) {
         coap_res_ptr->token_len = coap_packet_ptr->token_len;
-        coap_res_ptr->token_ptr = handle->sn_coap_protocol_malloc(coap_res_ptr->token_len);
+        coap_res_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, coap_packet_ptr->token_ptr, coap_res_ptr->token_len);
         if (!coap_res_ptr->token_ptr) {
             tr_error("sn_coap_build_response - failed to allocate token!");
             handle->sn_coap_protocol_free(coap_res_ptr);
             return NULL;
         }
-        memcpy(coap_res_ptr->token_ptr, coap_packet_ptr->token_ptr, coap_res_ptr->token_len);
     }
     return coap_res_ptr;
 }

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -117,6 +117,7 @@ int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src
         return -1;
     }
 
+    // XXX: this should not be needed anymore but I have no courage to remove it yet.
     memset(dst_packet_data_ptr, 0, dst_byte_count_to_be_built);
 
     /* * * * Store base (= original) destination Packet data pointer for later usage * * * */

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -37,17 +37,17 @@
 
 #define TRACE_GROUP "coap"
 /* * * * LOCAL FUNCTION PROTOTYPES * * * */
-static int8_t   sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr);
-static int8_t   sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr);
-static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, uint8_t *query_ptr, sn_coap_option_numbers_e option);
-static int16_t  sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet_data_pptr, uint16_t option_len, uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
-static int16_t  sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_packet_data_pptr, uint8_t **src_pptr, uint16_t *src_len_ptr, sn_coap_option_numbers_e option, uint16_t *previous_option_number);
+static int8_t   sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
+static int8_t   sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
+static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
+static int16_t  sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet_data_pptr, uint16_t option_len, const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
+static int16_t  sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_packet_data_pptr, const uint8_t *src_pptr, uint16_t src_len_ptr, sn_coap_option_numbers_e option, uint16_t *previous_option_number);
 static uint8_t  sn_coap_builder_options_build_add_uint_option(uint8_t **dst_packet_data_pptr, uint32_t value, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
-static uint8_t  sn_coap_builder_options_get_option_part_count(uint16_t query_len, uint8_t *query_ptr, sn_coap_option_numbers_e option);
-static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
-static int16_t  sn_coap_builder_options_get_option_part_position(uint16_t query_len, uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
-static void     sn_coap_builder_payload_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr);
-static uint8_t  sn_coap_builder_options_calculate_jump_need(sn_coap_hdr_s *src_coap_msg_ptr/*, uint8_t block_option*/);
+static uint8_t  sn_coap_builder_options_get_option_part_count(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
+static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, const uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
+static int16_t  sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
+static void     sn_coap_builder_payload_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
+static uint8_t  sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *src_coap_msg_ptr/*, uint8_t block_option*/);
 
 sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
 {
@@ -370,7 +370,7 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
  * \return Returns bytes needed for jumping
  */
 
-static uint8_t sn_coap_builder_options_calculate_jump_need(sn_coap_hdr_s *src_coap_msg_ptr/*, uint8_t block_option*/)
+static uint8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *src_coap_msg_ptr/*, uint8_t block_option*/)
 {
     uint8_t previous_option_number = 0;
     uint8_t needed_space           = 0;
@@ -499,7 +499,7 @@ static uint8_t sn_coap_builder_options_calculate_jump_need(sn_coap_hdr_s *src_co
  *
  * \return Return value is 0 in ok case and -1 in failure case
  **************************************************************************** */
-static int8_t sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr)
+static int8_t sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     /* * * * Check validity of Header values * * * */
     if (sn_coap_header_validity_check(src_coap_msg_ptr, COAP_VERSION) != 0) {
@@ -542,7 +542,7 @@ static int8_t sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, sn_co
  *
  * \return Return value is 0 in every case
  */
-static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr)
+static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     /* * * * Check if Options are used at all  * * * */
     if (src_coap_msg_ptr->uri_path_ptr == NULL && src_coap_msg_ptr->token_ptr == NULL &&
@@ -574,8 +574,8 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_c
                      src_coap_msg_ptr->options_list_ptr->uri_host_ptr, COAP_OPTION_URI_HOST, &previous_option_number);
 
         /* * * * Build ETag option  * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, &src_coap_msg_ptr->options_list_ptr->etag_ptr,
-                     (uint16_t *)&src_coap_msg_ptr->options_list_ptr->etag_len, COAP_OPTION_ETAG, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->etag_ptr,
+                     src_coap_msg_ptr->options_list_ptr->etag_len, COAP_OPTION_ETAG, &previous_option_number);
 
         /* * * * Build Observe option  * * * * */
         if (src_coap_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
@@ -590,12 +590,12 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_c
         }
 
         /* * * * Build Location-Path option  * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, &src_coap_msg_ptr->options_list_ptr->location_path_ptr,
-                     &src_coap_msg_ptr->options_list_ptr->location_path_len, COAP_OPTION_LOCATION_PATH, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->location_path_ptr,
+                     src_coap_msg_ptr->options_list_ptr->location_path_len, COAP_OPTION_LOCATION_PATH, &previous_option_number);
     }
     /* * * * Build Uri-Path option * * * */
-    sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, &src_coap_msg_ptr->uri_path_ptr,
-             &src_coap_msg_ptr->uri_path_len, COAP_OPTION_URI_PATH, &previous_option_number);
+    sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->uri_path_ptr,
+             src_coap_msg_ptr->uri_path_len, COAP_OPTION_URI_PATH, &previous_option_number);
 
     /* * * * Build Content-Type option * * * */
     if (src_coap_msg_ptr->content_format != COAP_CT_NONE) {
@@ -611,8 +611,8 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_c
         }
 
         /* * * * Build Uri-Query option  * * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, &src_coap_msg_ptr->options_list_ptr->uri_query_ptr,
-                     &src_coap_msg_ptr->options_list_ptr->uri_query_len, COAP_OPTION_URI_QUERY, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->uri_query_ptr,
+                     src_coap_msg_ptr->options_list_ptr->uri_query_len, COAP_OPTION_URI_QUERY, &previous_option_number);
 
         /* * * * Build Accept option  * * * * */
         if (src_coap_msg_ptr->options_list_ptr->accept != COAP_CT_NONE) {
@@ -623,8 +623,8 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_c
 
     if (src_coap_msg_ptr->options_list_ptr != NULL) {
         /* * * * Build Location-Query option * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, &src_coap_msg_ptr->options_list_ptr->location_query_ptr,
-                     &src_coap_msg_ptr->options_list_ptr->location_query_len, COAP_OPTION_LOCATION_QUERY, &previous_option_number);
+        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->options_list_ptr->location_query_ptr,
+                     src_coap_msg_ptr->options_list_ptr->location_query_len, COAP_OPTION_LOCATION_QUERY, &previous_option_number);
 
         /* * * * Build Block2 option * * * * */
         if (src_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE) {
@@ -676,7 +676,7 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_c
  * \return Return value is 0 if option was not added, 1 if added
  */
 static int16_t sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet_data_pptr, uint16_t option_len,
-        uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number)
+        const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number)
 {
     /* Check if there is option at all */
     if (option_ptr != NULL) {
@@ -793,21 +793,21 @@ static uint8_t sn_coap_builder_options_build_add_uint_option(uint8_t **dst_packe
  *
  * \param **dst_packet_data_pptr is destination for built Packet data
  *
- * \param uint8_t **src_pptr
+ * \param uint8_t **src_ptr
  *
- *  \param uint16_t *src_len_ptr
+ *  \param uint16_t src_len
  *
  *  \paramsn_coap_option_numbers_e option option to be added
  *
  * \return Return value is 0 always
  */
-static int16_t sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_packet_data_pptr, uint8_t **src_pptr, uint16_t *src_len_ptr, sn_coap_option_numbers_e option, uint16_t *previous_option_number)
+static int16_t sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_packet_data_pptr, const uint8_t *src_pptr, uint16_t src_len, sn_coap_option_numbers_e option, uint16_t *previous_option_number)
 {
     /* Check if there is option at all */
-    if (*src_pptr != NULL) {
-        uint8_t    *query_ptr               = *src_pptr;
+    if (src_pptr != NULL) {
+        const uint8_t *query_ptr            = src_pptr;
         uint8_t     query_part_count        = 0;
-        uint16_t    query_len               = *src_len_ptr;
+        uint16_t    query_len               = src_len;
         uint8_t     i                       = 0;
         uint16_t    query_part_offset       = 0;
 
@@ -823,7 +823,7 @@ static int16_t sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_p
             query_part_offset = sn_coap_builder_options_get_option_part_position(query_len, query_ptr, i, option);
 
             /* Add Uri-query's one part to Options */
-            sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, one_query_part_len, *src_pptr + query_part_offset, option, previous_option_number);
+            sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, one_query_part_len, src_pptr + query_part_offset, option, previous_option_number);
         }
     }
     /* Success */
@@ -842,7 +842,7 @@ static int16_t sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_p
  *
  * \return Return value is count of needed memory as bytes for Uri-query option
  */
-static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, uint8_t *query_ptr, sn_coap_option_numbers_e option)
+static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
 {
     uint8_t     query_part_count    = sn_coap_builder_options_get_option_part_count(query_len, query_ptr, option);
     uint8_t     i                   = 0;
@@ -923,7 +923,7 @@ static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, uin
  *
  * \return Return value is count of query parts
  */
-static uint8_t sn_coap_builder_options_get_option_part_count(uint16_t query_len, uint8_t *query_ptr, sn_coap_option_numbers_e option)
+static uint8_t sn_coap_builder_options_get_option_part_count(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
 {
     uint8_t  returned_query_count = 0;
     uint16_t query_len_index      = 0;
@@ -963,7 +963,7 @@ static uint8_t sn_coap_builder_options_get_option_part_count(uint16_t query_len,
  *
  * \return Return value is length of query part
  */
-static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, uint8_t *query_ptr,
+static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, const uint8_t *query_ptr,
         uint8_t query_index, sn_coap_option_numbers_e option)
 {
     uint16_t returned_query_part_len = 0;
@@ -1021,7 +1021,7 @@ static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option
  * \return Return value is position (= offset) of query part in whole query. In
  *         fail cases -1 is returned.
  */
-static int16_t sn_coap_builder_options_get_option_part_position(uint16_t query_len, uint8_t *query_ptr,
+static int16_t sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr,
         uint8_t query_index, sn_coap_option_numbers_e option)
 {
     uint16_t returned_query_part_offset = 0;
@@ -1076,7 +1076,7 @@ static int16_t sn_coap_builder_options_get_option_part_position(uint16_t query_l
  *
  * \param *src_coap_msg_ptr is source for building Packet data
  */
-static void sn_coap_builder_payload_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr)
+static void sn_coap_builder_payload_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     /* Check if Payload is used at all */
     if (src_coap_msg_ptr->payload_len && src_coap_msg_ptr->payload_ptr != NULL) {

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -699,7 +699,7 @@ static int16_t sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet
             first_byte = 0x0D;
         }
 
-        else if (option_len >= 269) {
+        else /*if (option_len >= 269)*/ {
             first_byte = 0x0E;
         }
 
@@ -719,7 +719,7 @@ static int16_t sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet
             dest_packet += 2;
         }
         //This is currently dead code (but possibly needed in future)
-        else if (option_delta >= 269) {
+        else /*if (option_delta >= 269)*/ {
             dest_packet[0] = first_byte + 0xE0;
             option_delta -= 269;
 
@@ -783,11 +783,9 @@ static uint8_t sn_coap_builder_options_build_add_uint_option(uint8_t **dst_packe
 
     /* If output pointer isn't NULL, write it out */
     if (dst_packet_data_pptr) {
-        int16_t ret = sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, len, payload, option_number, previous_option_number);
-        /* Allow for failure returns when writing (why even permit failure returns?) */
-        if (ret < 0) {
-            return ret;
-        }
+        // No need to check & handle return value, as the function returns failure only if the option pointer is zero
+        // and it is pointing to a local variable here.
+        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, len, payload, option_number, previous_option_number);
     }
 
     /* Return the total option size */

--- a/source/sn_coap_header_check.c
+++ b/source/sn_coap_header_check.c
@@ -44,7 +44,7 @@
  * \return Return value is status of validity check. In ok cases 0 and in
  *         failure cases -1
  */
-int8_t sn_coap_header_validity_check(sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version)
+int8_t sn_coap_header_validity_check(const sn_coap_hdr_s *src_coap_msg_ptr, coap_version_e coap_version)
 {
     /* * Check validity of CoAP Version * */
     if (coap_version != COAP_VERSION_1) {

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -180,27 +180,35 @@ void sn_coap_parser_release_allocated_coap_msg_mem(struct coap_s *handle, sn_coa
     }
 
     if (freed_coap_msg_ptr != NULL) {
-        handle->sn_coap_protocol_free(freed_coap_msg_ptr->uri_path_ptr);
-        handle->sn_coap_protocol_free(freed_coap_msg_ptr->token_ptr);
 
-        if (freed_coap_msg_ptr->options_list_ptr != NULL) {
+        // As there are multiple sequential calls to the protocol_free, caching pointer to it
+        // saves one instruction per call.
+        void (*local_free)(void *) = handle->sn_coap_protocol_free;
 
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->proxy_uri_ptr);
+        local_free(freed_coap_msg_ptr->uri_path_ptr);
+        local_free(freed_coap_msg_ptr->token_ptr);
 
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->etag_ptr);
+        // same here, caching the struct start saves a bit.
+        sn_coap_options_list_s *options_list_ptr = freed_coap_msg_ptr->options_list_ptr;
 
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_host_ptr);
+        if (options_list_ptr != NULL) {
 
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_path_ptr);
+            local_free(options_list_ptr->proxy_uri_ptr);
 
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_query_ptr);
+            local_free(options_list_ptr->etag_ptr);
 
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_query_ptr);
+            local_free(options_list_ptr->uri_host_ptr);
 
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr);
+            local_free(options_list_ptr->location_path_ptr);
+
+            local_free(options_list_ptr->location_query_ptr);
+
+            local_free(options_list_ptr->uri_query_ptr);
+
+            local_free(options_list_ptr);
         }
 
-        handle->sn_coap_protocol_free(freed_coap_msg_ptr);
+        local_free(freed_coap_msg_ptr);
     }
 }
 

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -64,6 +64,29 @@ sn_coap_hdr_s *sn_coap_parser_init_message(sn_coap_hdr_s *coap_msg_ptr)
     return coap_msg_ptr;
 }
 
+sn_coap_hdr_s *sn_coap_parser_alloc_message_with_options(struct coap_s *handle)
+{
+    // check the handle just as in any other place
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    sn_coap_hdr_s *coap_msg_ptr = sn_coap_parser_alloc_message(handle);
+
+    sn_coap_options_list_s *options_list_ptr = sn_coap_parser_alloc_options(handle, coap_msg_ptr);
+
+    if ((coap_msg_ptr == NULL) || (options_list_ptr == NULL)) {
+
+        // oops, out of memory free if got already any
+        handle->sn_coap_protocol_free(coap_msg_ptr);
+        handle->sn_coap_protocol_free(options_list_ptr);
+
+        coap_msg_ptr = NULL;
+    }
+
+    return coap_msg_ptr;
+}
+
 sn_coap_hdr_s *sn_coap_parser_alloc_message(struct coap_s *handle)
 {
     sn_coap_hdr_s *returned_coap_msg_ptr;
@@ -109,7 +132,6 @@ sn_coap_options_list_s *sn_coap_parser_alloc_options(struct coap_s *handle, sn_c
     options_list_ptr->accept = COAP_CT_NONE;
     options_list_ptr->block2 = COAP_OPTION_BLOCK_NONE;
     options_list_ptr->block1 = COAP_OPTION_BLOCK_NONE;
-
 
     return options_list_ptr;
 }

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -156,38 +156,22 @@ void sn_coap_parser_release_allocated_coap_msg_mem(struct coap_s *handle, sn_coa
     }
 
     if (freed_coap_msg_ptr != NULL) {
-        if (freed_coap_msg_ptr->uri_path_ptr != NULL) {
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->uri_path_ptr);
-        }
-
-        if (freed_coap_msg_ptr->token_ptr != NULL) {
-            handle->sn_coap_protocol_free(freed_coap_msg_ptr->token_ptr);
-        }
+        handle->sn_coap_protocol_free(freed_coap_msg_ptr->uri_path_ptr);
+        handle->sn_coap_protocol_free(freed_coap_msg_ptr->token_ptr);
 
         if (freed_coap_msg_ptr->options_list_ptr != NULL) {
-            if (freed_coap_msg_ptr->options_list_ptr->proxy_uri_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->proxy_uri_ptr);
-            }
 
-            if (freed_coap_msg_ptr->options_list_ptr->etag_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->etag_ptr);
-            }
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->proxy_uri_ptr);
 
-            if (freed_coap_msg_ptr->options_list_ptr->uri_host_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_host_ptr);
-            }
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->etag_ptr);
 
-            if (freed_coap_msg_ptr->options_list_ptr->location_path_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_path_ptr);
-            }
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_host_ptr);
 
-            if (freed_coap_msg_ptr->options_list_ptr->location_query_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_query_ptr);
-            }
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_path_ptr);
 
-            if (freed_coap_msg_ptr->options_list_ptr->uri_query_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_query_ptr);
-            }
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->location_query_ptr);
+
+            handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr->uri_query_ptr);
 
             handle->sn_coap_protocol_free(freed_coap_msg_ptr->options_list_ptr);
         }

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -253,14 +253,13 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
             return -1;
         }
 
-        dst_coap_msg_ptr->token_ptr = handle->sn_coap_protocol_malloc(dst_coap_msg_ptr->token_len);
+        dst_coap_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, *packet_data_pptr, dst_coap_msg_ptr->token_len);
 
         if (dst_coap_msg_ptr->token_ptr == NULL) {
             tr_error("sn_coap_parser_options_parse - failed to allocate token!");
             return -1;
         }
 
-        memcpy(dst_coap_msg_ptr->token_ptr, *packet_data_pptr, dst_coap_msg_ptr->token_len);
         (*packet_data_pptr) += dst_coap_msg_ptr->token_len;
     }
 
@@ -363,14 +362,13 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
                 dst_coap_msg_ptr->options_list_ptr->proxy_uri_len = option_len;
                 (*packet_data_pptr)++;
 
-                dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr = handle->sn_coap_protocol_malloc(option_len);
+                dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr = sn_coap_protocol_malloc_copy(handle, *packet_data_pptr, option_len);
 
                 if (dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr == NULL) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_PROXY_URI allocation failed!");
                     return -1;
                 }
 
-                memcpy(dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr, *packet_data_pptr, option_len);
                 (*packet_data_pptr) += option_len;
 
                 break;
@@ -399,13 +397,12 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
                 dst_coap_msg_ptr->options_list_ptr->uri_host_len = option_len;
                 (*packet_data_pptr)++;
 
-                dst_coap_msg_ptr->options_list_ptr->uri_host_ptr = handle->sn_coap_protocol_malloc(option_len);
+                dst_coap_msg_ptr->options_list_ptr->uri_host_ptr = sn_coap_protocol_malloc_copy(handle, *packet_data_pptr, option_len);
 
                 if (dst_coap_msg_ptr->options_list_ptr->uri_host_ptr == NULL) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_URI_HOST allocation failed!");
                     return -1;
                 }
-                memcpy(dst_coap_msg_ptr->options_list_ptr->uri_host_ptr, *packet_data_pptr, option_len);
                 (*packet_data_pptr) += option_len;
 
                 break;
@@ -607,9 +604,9 @@ static int8_t sn_coap_parser_options_parse_multiple_options(struct coap_s *handl
             /* Uri-Query is modified to following format: temp1'\0'temp2'\0'temp3 i.e.  */
             /* Uri-Path is modified to following format: temp1\temp2\temp3 i.e.  */
             if (option == COAP_OPTION_URI_QUERY || option == COAP_OPTION_LOCATION_QUERY || option == COAP_OPTION_ETAG || option == COAP_OPTION_ACCEPT) {
-                memset(temp_parsed_uri_query_ptr, '&', 1);
+                *temp_parsed_uri_query_ptr = '&';
             } else if (option == COAP_OPTION_URI_PATH || option == COAP_OPTION_LOCATION_PATH) {
-                memset(temp_parsed_uri_query_ptr, '/', 1);
+                *temp_parsed_uri_query_ptr = '/';
             }
 
             temp_parsed_uri_query_ptr++;

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -62,7 +62,7 @@ static uint8_t              *sn_coap_protocol_linked_list_blockwise_payload_sear
 static bool                  sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, const uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s *handle, coap_blockwise_payload_s *removed_payload_ptr);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(struct coap_s *handle, uint8_t *token_ptr, uint8_t token_len);
-static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len);
+static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, const uint8_t *token_ptr, uint8_t token_len);
 static void                  sn_coap_protocol_handle_blockwise_timout(struct coap_s *handle);
 static sn_coap_hdr_s        *sn_coap_handle_blockwise_message(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr, void *param);
 static bool                  sn_coap_handle_last_blockwise(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr);
@@ -1391,7 +1391,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s 
  * \return Return value is length of Payloads as bytes
  *****************************************************************************/
 
-static uint32_t sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len)
+static uint32_t sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, const uint8_t *token_ptr, uint8_t token_len)
 {
     uint32_t ret_whole_payload_len = 0;
     /* Loop all stored blockwise payloads in Linked list */

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -855,7 +855,7 @@ rescan:
 
                         if (tmp_coap_hdr_ptr != 0) {
                             tmp_coap_hdr_ptr->coap_status = COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED;
-                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
+                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                             sn_coap_parser_release_allocated_coap_msg_mem(stored_msg_ptr->coap, tmp_coap_hdr_ptr);
                         }
@@ -866,7 +866,7 @@ rescan:
                 } else {
                     /* Send message  */
                     stored_msg_ptr->coap->sn_coap_tx_callback(stored_msg_ptr->send_msg_ptr.packet_ptr,
-                            stored_msg_ptr->send_msg_ptr.packet_len, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
+                            stored_msg_ptr->send_msg_ptr.packet_len, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                     /* * * Count new Resending time  * * */
                     stored_msg_ptr->resending_time = sn_coap_calculate_new_resend_time(current_time,
@@ -949,10 +949,10 @@ static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle
     memcpy(stored_msg_ptr->send_msg_ptr.packet_ptr, send_packet_data_ptr, send_packet_data_len);
 
     /* Filling of sn_nsdl_addr_s */
-    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->type = dst_addr_ptr->type;
-    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_len = dst_addr_ptr->addr_len;
-    memcpy(stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
-    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port = dst_addr_ptr->port;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr.type = dst_addr_ptr->type;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_len = dst_addr_ptr->addr_len;
+    memcpy(stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port = dst_addr_ptr->port;
 
     stored_msg_ptr->coap = handle;
     stored_msg_ptr->param = param;
@@ -988,9 +988,9 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port == src_addr_ptr->port) {
                     /* * * Message found, return pointer to that stored resending message * * * */
                     return &stored_msg_ptr->send_msg_ptr;
                 }
@@ -1021,9 +1021,9 @@ static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port == src_addr_ptr->port) {
                     /* * * Message found * * */
 
                     /* Remove message from Linked list */
@@ -1590,15 +1590,6 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 
     memset(msg_ptr, 0, sizeof(coap_send_msg_s));
 
-    msg_ptr->send_msg_ptr.dst_addr_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
-
-    if (msg_ptr->send_msg_ptr.dst_addr_ptr == NULL) {
-        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
-        return 0;
-    }
-
-    memset(msg_ptr->send_msg_ptr.dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
-
     msg_ptr->send_msg_ptr.packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
 
     if (msg_ptr->send_msg_ptr.packet_ptr == NULL) {
@@ -1606,14 +1597,14 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
         return 0;
     }
 
-    msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
+    msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
 
-    if (msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    memset(msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, 0, dst_addr_ptr->addr_len);
+    memset(msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, 0, dst_addr_ptr->addr_len);
 
     return msg_ptr;
 }
@@ -1630,15 +1621,10 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr)
 {
     if (freed_send_msg_ptr != NULL) {
-        if (freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr != NULL) {
 
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr);
-
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr);
-        }
+        handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr);
 
         handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.packet_ptr);
-
 
         handle->sn_coap_protocol_free(freed_send_msg_ptr);
     }

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -1884,9 +1884,9 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
     else {
         //This is response to request we made
         if (received_coap_msg_ptr->msg_code > COAP_MSG_CODE_REQUEST_DELETE) {
+#if SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED
             if (handle->sn_coap_internal_block2_resp_handling) {
                 uint32_t block_number = 0;
-
                 /* Store blockwise payload to Linked list */
                 //todo: add block number to stored values - just to make sure all packets are in order
                 sn_coap_protocol_linked_list_blockwise_payload_store(handle,
@@ -2020,6 +2020,12 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     //todo: remove previous msg from list
                 }
             }
+#else
+            // If the internal handling is disabled, this code should not be ran unless
+            // the client messed up in its own handler.
+            tr_error("sn_coap_handle_blockwise_message - (send block2) - callback not set");
+            return NULL;
+#endif
         }
 
         //Now we send data to request

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -97,21 +97,15 @@ int8_t sn_coap_protocol_destroy(struct coap_s *handle)
     ns_list_foreach_safe(coap_duplication_info_s, tmp, &handle->linked_list_duplication_msgs) {
         if (tmp->coap == handle) {
             if (tmp->address) {
-                if (tmp->address->addr_ptr) {
-                    handle->sn_coap_protocol_free(tmp->address->addr_ptr);
-                    tmp->address->addr_ptr = 0;
-                }
+
+                handle->sn_coap_protocol_free(tmp->address->addr_ptr);
                 handle->sn_coap_protocol_free(tmp->address);
-                tmp->address = 0;
             }
-            if (tmp->packet_ptr) {
-                handle->sn_coap_protocol_free(tmp->packet_ptr);
-                tmp->packet_ptr = 0;
-            }
+            handle->sn_coap_protocol_free(tmp->packet_ptr);
+
             ns_list_remove(&handle->linked_list_duplication_msgs, tmp);
             handle->count_duplication_msgs--;
             handle->sn_coap_protocol_free(tmp);
-            tmp = 0;
         }
     }
 
@@ -138,7 +132,6 @@ int8_t sn_coap_protocol_destroy(struct coap_s *handle)
 #endif
 
     handle->sn_coap_protocol_free(handle);
-    handle = 0;
     return 0;
 }
 
@@ -541,7 +534,6 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         stored_blockwise_msg_ptr->coap_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
         if( stored_blockwise_msg_ptr->coap_msg_ptr == NULL ){
             handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
-            stored_blockwise_msg_ptr = 0;
             tr_error("sn_coap_protocol_build - block header copy failed!");
             return -2;
         }
@@ -553,7 +545,6 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
             //block payload save failed, only first block can be build. Perhaps we should return error.
             sn_coap_parser_release_allocated_coap_msg_mem(handle, stored_blockwise_msg_ptr->coap_msg_ptr);
             handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
-            stored_blockwise_msg_ptr = 0;
             tr_error("sn_coap_protocol_build - block payload allocation failed!");
             return byte_count_built;
         }
@@ -581,7 +572,6 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         stored_blockwise_msg_ptr->coap_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
         if( stored_blockwise_msg_ptr->coap_msg_ptr == NULL ){
             handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
-            stored_blockwise_msg_ptr = 0;
             tr_error("sn_coap_protocol_build - blockwise (GET) copy header failed!");
             return -2;
         }
@@ -774,7 +764,6 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
             }
 
             handle->sn_coap_protocol_free(stored_blockwise_msg_temp_ptr);
-            stored_blockwise_msg_temp_ptr = 0;
         }
     }
 
@@ -1117,7 +1106,6 @@ static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *h
     if (stored_duplication_info_ptr->address == NULL) {
         tr_error("sn_coap_protocol_linked_list_duplication_info_store - failed to allocate address!");
         handle->sn_coap_protocol_free(stored_duplication_info_ptr);
-        stored_duplication_info_ptr = 0;
         return;
     }
     memset(stored_duplication_info_ptr->address, 0, sizeof(sn_nsdl_addr_s));
@@ -1127,9 +1115,7 @@ static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *h
     if (stored_duplication_info_ptr->address->addr_ptr == NULL) {
         tr_error("sn_coap_protocol_linked_list_duplication_info_store - failed to allocate address pointer!");
         handle->sn_coap_protocol_free(stored_duplication_info_ptr->address);
-        stored_duplication_info_ptr->address = 0;
         handle->sn_coap_protocol_free(stored_duplication_info_ptr);
-        stored_duplication_info_ptr = 0;
         return;
     }
 
@@ -1199,13 +1185,9 @@ static void sn_coap_protocol_linked_list_duplication_info_remove_old_ones(struct
 
             /* Free memory of stored Duplication info */
             handle->sn_coap_protocol_free(removed_duplication_info_ptr->address->addr_ptr);
-            removed_duplication_info_ptr->address->addr_ptr = 0;
             handle->sn_coap_protocol_free(removed_duplication_info_ptr->address);
-            removed_duplication_info_ptr->address = 0;
             handle->sn_coap_protocol_free(removed_duplication_info_ptr->packet_ptr);
-            removed_duplication_info_ptr->packet_ptr = 0;
             handle->sn_coap_protocol_free(removed_duplication_info_ptr);
-            removed_duplication_info_ptr = 0;
         }
     }
 }
@@ -1232,13 +1214,9 @@ void sn_coap_protocol_linked_list_duplication_info_remove(struct coap_s *handle,
 
                     /* Free memory of stored Duplication info */
                     handle->sn_coap_protocol_free(removed_duplication_info_ptr->address->addr_ptr);
-                    removed_duplication_info_ptr->address->addr_ptr = 0;
                     handle->sn_coap_protocol_free(removed_duplication_info_ptr->address);
-                    removed_duplication_info_ptr->address = 0;
                     handle->sn_coap_protocol_free(removed_duplication_info_ptr->packet_ptr);
-                    removed_duplication_info_ptr->packet_ptr = 0;
                     handle->sn_coap_protocol_free(removed_duplication_info_ptr);
-                    removed_duplication_info_ptr = 0;
                     return;
                 }
             }
@@ -1336,7 +1314,6 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
     if (stored_blockwise_payload_ptr->payload_ptr == NULL) {
         tr_error("sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate payload!");
         handle->sn_coap_protocol_free(stored_blockwise_payload_ptr);
-        stored_blockwise_payload_ptr = 0;
         return;
     }
 
@@ -1346,10 +1323,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
     if (stored_blockwise_payload_ptr->addr_ptr == NULL) {
         tr_error("sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate address pointer!");
         handle->sn_coap_protocol_free(stored_blockwise_payload_ptr->payload_ptr);
-        stored_blockwise_payload_ptr->payload_ptr = 0;
         handle->sn_coap_protocol_free(stored_blockwise_payload_ptr);
-        stored_blockwise_payload_ptr = 0;
-
         return;
     }
 
@@ -1492,23 +1466,14 @@ static void sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s 
 {
     ns_list_remove(&handle->linked_list_blockwise_received_payloads, removed_payload_ptr);
     /* Free memory of stored payload */
-    if (removed_payload_ptr->addr_ptr != NULL) {
-        handle->sn_coap_protocol_free(removed_payload_ptr->addr_ptr);
-        removed_payload_ptr->addr_ptr = 0;
-    }
-
-    if (removed_payload_ptr->payload_ptr != NULL) {
-        handle->sn_coap_protocol_free(removed_payload_ptr->payload_ptr);
-        removed_payload_ptr->payload_ptr = 0;
-    }
-
+    handle->sn_coap_protocol_free(removed_payload_ptr->addr_ptr);
+    handle->sn_coap_protocol_free(removed_payload_ptr->payload_ptr);
     if (removed_payload_ptr->token_ptr != NULL) {
         handle->sn_coap_protocol_free(removed_payload_ptr->token_ptr);
         removed_payload_ptr->token_ptr = 0;
     }
 
     handle->sn_coap_protocol_free(removed_payload_ptr);
-    removed_payload_ptr = 0;
 }
 
 /**************************************************************************//**
@@ -1574,7 +1539,6 @@ rescan:
                     handle->sn_coap_rx_callback(removed_blocwise_msg_ptr->coap_msg_ptr, NULL, removed_blocwise_msg_ptr->param);
                     callback_called = true;
                 }
-
                 handle->sn_coap_protocol_free(removed_blocwise_msg_ptr->coap_msg_ptr->payload_ptr);
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, removed_blocwise_msg_ptr->coap_msg_ptr);
             }
@@ -1677,26 +1641,18 @@ static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handl
     if (freed_send_msg_ptr != NULL) {
         if (freed_send_msg_ptr->send_msg_ptr != NULL) {
             if (freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr != NULL) {
-                if (freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr != NULL) {
-                    handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr);
-                    freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr = 0;
-                }
+
+                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr);
 
                 handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr);
-                freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr = 0;
             }
 
-            if (freed_send_msg_ptr->send_msg_ptr->packet_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->packet_ptr);
-                freed_send_msg_ptr->send_msg_ptr->packet_ptr = 0;
-            }
+            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->packet_ptr);
 
             handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr);
-            freed_send_msg_ptr->send_msg_ptr = 0;
         }
 
         handle->sn_coap_protocol_free(freed_send_msg_ptr);
-        freed_send_msg_ptr = NULL;
     }
 }
 
@@ -1879,11 +1835,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     if (!dst_ack_packet_data_ptr) {
                         tr_error("sn_coap_handle_blockwise_message - (send block1) failed to allocate ack message!");
                         handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->options_list_ptr);
-                        src_coap_blockwise_ack_msg_ptr->options_list_ptr = 0;
                         handle->sn_coap_protocol_free(original_payload_ptr);
-                        original_payload_ptr = 0;
                         handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                        src_coap_blockwise_ack_msg_ptr = 0;
                         stored_blockwise_msg_temp_ptr->coap_msg_ptr = NULL;
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
@@ -1967,7 +1920,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 if (sn_coap_parser_alloc_options(handle, src_coap_blockwise_ack_msg_ptr) == NULL) {
                    tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate options!");
                     handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                    src_coap_blockwise_ack_msg_ptr = 0;
                     sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                     return NULL;
                 }
@@ -2028,9 +1980,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     tr_error("sn_coap_handle_blockwise_message - (recv block1) message allocation failed!");
                     sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                     handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->options_list_ptr);
-                    src_coap_blockwise_ack_msg_ptr->options_list_ptr = 0;
                     handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                    src_coap_blockwise_ack_msg_ptr = 0;
                     return NULL;
                 }
 
@@ -2223,7 +2173,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     if (!stored_blockwise_msg_ptr) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate blockwise message!");
                         handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
-                        dst_ack_packet_data_ptr = 0;
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return 0;
@@ -2360,10 +2309,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 dst_ack_packet_data_ptr = handle->sn_coap_protocol_malloc(dst_packed_data_needed_mem);
                 if (!dst_ack_packet_data_ptr) {
                     tr_error("sn_coap_handle_blockwise_message - (recv block2) failed to allocate packet!");
-                    if(original_payload_ptr){
-                        handle->sn_coap_protocol_free(original_payload_ptr);
-                        original_payload_ptr = NULL;
-                    }
+                    handle->sn_coap_protocol_free(original_payload_ptr);
                     sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                     stored_blockwise_msg_temp_ptr->coap_msg_ptr = NULL;
                     return NULL;

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -57,8 +57,8 @@ static bool                  sn_coap_protocol_update_duplicate_package_data(cons
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
 static void                  sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *handle, coap_blockwise_msg_s *removed_msg_ptr);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *handle, sn_nsdl_addr_s *addr_ptr, uint16_t stored_payload_len, uint8_t *stored_payload_ptr, uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
-static uint8_t              *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length, uint8_t *token_ptr, uint8_t token_len);
-static bool                  sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
+static uint8_t              *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length, const uint8_t *token_ptr, uint8_t token_len);
+static bool                  sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, const uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s *handle, coap_blockwise_payload_s *removed_payload_ptr);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(struct coap_s *handle, uint8_t *token_ptr, uint8_t token_len);
 static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len);
@@ -69,13 +69,15 @@ static sn_coap_hdr_s        *sn_coap_protocol_copy_header(struct coap_s *handle,
 
 #if ENABLE_RESENDINGS
 static uint8_t               sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t send_packet_data_len, uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param);
-static sn_nsdl_transmit_s   *sn_coap_protocol_linked_list_send_msg_search(struct coap_s *handle,sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
-static void                  sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
+static sn_nsdl_transmit_s   *sn_coap_protocol_linked_list_send_msg_search(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
+static void                  sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
 static coap_send_msg_s      *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t packet_data_len);
 static void                  sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr);
 static uint16_t              sn_coap_count_linked_list_size(const coap_send_msg_list_t *linked_list_ptr);
 static uint32_t              sn_coap_calculate_new_resend_time(const uint32_t current_time, const uint8_t interval, const uint8_t counter);
 #endif
+
+static bool                  compare_address_and_port(const sn_nsdl_addr_s* left, const sn_nsdl_addr_s* right);
 
 /* * * * * * * * * * * * * * * * * */
 /* * * * GLOBAL DECLARATIONS * * * */
@@ -974,7 +976,7 @@ static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle
  *****************************************************************************/
 
 static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct coap_s *handle,
-        sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id)
+        const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id)
 {
     /* Loop all stored resending messages Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
@@ -984,13 +986,10 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
-            /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, src_addr_ptr->addr_len)) {
-                /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port == src_addr_ptr->port) {
-                    /* * * Message found, return pointer to that stored resending message * * * */
-                    return &stored_msg_ptr->send_msg_ptr;
-                }
+            /* If message's Source address and port is same than is searched */
+            if (compare_address_and_port(src_addr_ptr, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr)) {
+                /* * * Message found, return pointer to that stored resending message * * * */
+                return &stored_msg_ptr->send_msg_ptr;
             }
         }
     }
@@ -1007,7 +1006,7 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
  * \param msg_id is searching key for removed message
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id)
+static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id)
 {
     /* Loop all stored resending messages in Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
@@ -1017,21 +1016,18 @@ static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, 
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
-            /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, src_addr_ptr->addr_len)) {
-                /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr.port == src_addr_ptr->port) {
-                    /* * * Message found * * */
+            /* If message's Source address and port is same than is searched */
+            if (compare_address_and_port(src_addr_ptr, &stored_msg_ptr->send_msg_ptr.dst_addr_ptr)) {
+                /* * * Message found * * */
 
-                    /* Remove message from Linked list */
-                    ns_list_remove(&handle->linked_list_resent_msgs, stored_msg_ptr);
-                    --handle->count_resent_msgs;
+                /* Remove message from Linked list */
+                ns_list_remove(&handle->linked_list_resent_msgs, stored_msg_ptr);
+                --handle->count_resent_msgs;
 
-                    /* Free memory of stored message */
-                    sn_coap_protocol_release_allocated_send_msg_mem(handle, stored_msg_ptr);
+                /* Free memory of stored message */
+                sn_coap_protocol_release_allocated_send_msg_mem(handle, stored_msg_ptr);
 
-                    return;
-                }
+                return;
             }
         }
     }
@@ -1368,7 +1364,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
  *         list or NULL if payload not found
  *****************************************************************************/
 
-static uint8_t *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length, uint8_t *token_ptr, uint8_t token_len)
+static uint8_t *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length, const uint8_t *token_ptr, uint8_t token_len)
 {
     /* Loop all stored blockwise payloads in Linked list */
     ns_list_foreach(coap_blockwise_payload_s, stored_payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
@@ -1392,8 +1388,8 @@ static uint8_t *sn_coap_protocol_linked_list_blockwise_payload_search(struct coa
 }
 
 static bool sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle,
-                                                                                   sn_nsdl_addr_s *src_addr_ptr,
-                                                                                   uint8_t *token_ptr,
+                                                                                   const sn_nsdl_addr_s *src_addr_ptr,
+                                                                                   const uint8_t *token_ptr,
                                                                                    uint8_t token_len,
                                                                                    uint32_t block_number)
 {
@@ -2492,4 +2488,17 @@ void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length)
         memset(result, 0, length);
     }
     return result;
+}
+
+static bool compare_address_and_port(const sn_nsdl_addr_s* left, const sn_nsdl_addr_s* right)
+{
+    bool match = false;
+
+    if (left->port == right->port) {
+        if (0 == memcmp(left->addr_ptr, right->addr_ptr, left->addr_len)) {
+            match = true;
+        }
+    }
+
+    return match;
 }

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -78,6 +78,7 @@ static uint16_t              sn_coap_count_linked_list_size(const coap_send_msg_
 static uint32_t              sn_coap_calculate_new_resend_time(const uint32_t current_time, const uint8_t interval, const uint8_t counter);
 #endif
 
+static uint16_t              read_packet_msg_id(const coap_send_msg_s *stored_msg);
 static uint16_t              get_new_message_id(void);
 
 static bool                  compare_address_and_port(const sn_nsdl_addr_s* left, const sn_nsdl_addr_s* right);
@@ -100,16 +101,10 @@ int8_t sn_coap_protocol_destroy(struct coap_s *handle)
 
 #if SN_COAP_DUPLICATION_MAX_MSGS_COUNT /* If Message duplication detection is not used at all, this part of code will not be compiled */
     ns_list_foreach_safe(coap_duplication_info_s, tmp, &handle->linked_list_duplication_msgs) {
-        if (tmp->address) {
-
-            handle->sn_coap_protocol_free(tmp->address->addr_ptr);
-            handle->sn_coap_protocol_free(tmp->address);
-        }
-        handle->sn_coap_protocol_free(tmp->packet_ptr);
 
         ns_list_remove(&handle->linked_list_duplication_msgs, tmp);
-        handle->count_duplication_msgs--;
-        handle->sn_coap_protocol_free(tmp);
+
+        sn_coap_protocol_duplication_info_free(handle, tmp);
     }
 
 #endif
@@ -344,10 +339,9 @@ int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint16_t ms
         return -1;
     }
     ns_list_foreach_safe(coap_send_msg_s, tmp, &handle->linked_list_resent_msgs) {
-        if (tmp->send_msg_ptr.packet_ptr ) {
-            uint16_t temp_msg_id = (tmp->send_msg_ptr.packet_ptr[2] << 8);
-            temp_msg_id += (uint16_t)tmp->send_msg_ptr.packet_ptr[3];
-            if(temp_msg_id == msg_id){
+        if (tmp->send_msg_ptr.packet_ptr) {
+            uint16_t temp_msg_id = read_packet_msg_id(tmp);
+            if (temp_msg_id == msg_id) {
                 ns_list_remove(&handle->linked_list_resent_msgs, tmp);
                 --handle->count_resent_msgs;
                 sn_coap_protocol_release_allocated_send_msg_mem(handle, tmp);
@@ -371,9 +365,8 @@ int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, co
         uint8_t stored_token_len =  (stored_msg->send_msg_ptr.packet_ptr[0] & 0x0F);
         if (stored_token_len == token_len) {
             if (memcmp(&stored_msg->send_msg_ptr.packet_ptr[4], token, stored_token_len) == 0) {
-                uint16_t temp_msg_id = (stored_msg->send_msg_ptr.packet_ptr[2] << 8);
-                temp_msg_id += (uint16_t)stored_msg->send_msg_ptr.packet_ptr[3];
-                tr_debug("sn_coap_protocol_delete_retransmission_by_token - removed msg_id: %d", temp_msg_id);
+
+                tr_debug("sn_coap_protocol_delete_retransmission_by_token - removed msg_id: %" PRIu16, read_packet_msg_id(stored_msg));
                 ns_list_remove(&handle->linked_list_resent_msgs, stored_msg);
                 --handle->count_resent_msgs;
 
@@ -387,6 +380,12 @@ int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, co
     return -2;
 }
 
+static uint16_t read_packet_msg_id(const coap_send_msg_s *stored_msg)
+{
+    uint16_t msg_id = (stored_msg->send_msg_ptr.packet_ptr[2] << 8);
+    msg_id += (uint16_t)stored_msg->send_msg_ptr.packet_ptr[3];
+    return msg_id;
+}
 
 int8_t prepare_blockwise_message(struct coap_s *handle, sn_coap_hdr_s *src_coap_msg_ptr)
 {
@@ -821,9 +820,6 @@ rescan:
             if (stored_msg_ptr->resending_counter > handle->sn_coap_resending_count) {
                 coap_version_e coap_version = COAP_VERSION_UNKNOWN;
 
-                /* Get message ID from stored sending message */
-                uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
-                temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
 
                 /* Remove message from Linked list */
                 ns_list_remove(&handle->linked_list_resent_msgs, stored_msg_ptr);
@@ -962,8 +958,7 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
     /* Loop all stored resending messages Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
         /* Get message ID from stored resending message */
-        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
-        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
+        uint16_t temp_msg_id = read_packet_msg_id(stored_msg_ptr);
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
@@ -992,8 +987,7 @@ static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, 
     /* Loop all stored resending messages in Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
         /* Get message ID from stored resending message */
-        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
-        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
+        uint16_t temp_msg_id = read_packet_msg_id(stored_msg_ptr);
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
@@ -1122,13 +1116,10 @@ static coap_duplication_info_s* sn_coap_protocol_linked_list_duplication_info_se
     ns_list_foreach(coap_duplication_info_s, stored_duplication_info_ptr, &handle->linked_list_duplication_msgs) {
         /* If message's Message ID is same than is searched */
         if (stored_duplication_info_ptr->msg_id == msg_id) {
-            /* If message's Source address is same than is searched */
-            if (0 == memcmp(addr_ptr->addr_ptr, stored_duplication_info_ptr->address->addr_ptr, addr_ptr->addr_len)) {
-                /* If message's Source address port is same than is searched */
-                if (stored_duplication_info_ptr->address->port == addr_ptr->port) {
-                    /* * * Correct Duplication info found * * * */
-                    return stored_duplication_info_ptr;
-                }
+            /* If message's Source address & port is same than is searched */
+            if (compare_address_and_port(addr_ptr, stored_duplication_info_ptr->address)) {
+                /* * * Correct Duplication info found * * * */
+                return stored_duplication_info_ptr;
             }
         }
     }
@@ -1145,7 +1136,7 @@ static coap_duplication_info_s* sn_coap_protocol_linked_list_duplication_info_se
 
 static void sn_coap_protocol_linked_list_duplication_info_remove_old_ones(struct coap_s *handle)
 {
-    /* Loop all stored duplication messages in Linked list */
+
     ns_list_foreach_safe(coap_duplication_info_s, removed_duplication_info_ptr, &handle->linked_list_duplication_msgs) {
         if ((handle->system_time - removed_duplication_info_ptr->timestamp)  > SN_COAP_DUPLICATION_MAX_TIME_MSGS_STORED) {
             /* * * * Old Duplication info found, remove it from Linked list * * * */

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -345,9 +345,9 @@ int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint16_t ms
         return -1;
     }
     ns_list_foreach_safe(coap_send_msg_s, tmp, &handle->linked_list_resent_msgs) {
-        if (tmp->send_msg_ptr && tmp->send_msg_ptr->packet_ptr ) {
-            uint16_t temp_msg_id = (tmp->send_msg_ptr->packet_ptr[2] << 8);
-            temp_msg_id += (uint16_t)tmp->send_msg_ptr->packet_ptr[3];
+        if (tmp->send_msg_ptr.packet_ptr ) {
+            uint16_t temp_msg_id = (tmp->send_msg_ptr.packet_ptr[2] << 8);
+            temp_msg_id += (uint16_t)tmp->send_msg_ptr.packet_ptr[3];
             if(temp_msg_id == msg_id){
                 ns_list_remove(&handle->linked_list_resent_msgs, tmp);
                 --handle->count_resent_msgs;
@@ -369,13 +369,13 @@ int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, ui
     }
 
     ns_list_foreach(coap_send_msg_s, stored_msg, &handle->linked_list_resent_msgs) {
-        uint8_t stored_token_len =  (stored_msg->send_msg_ptr->packet_ptr[0] & 0x0F);
+        uint8_t stored_token_len =  (stored_msg->send_msg_ptr.packet_ptr[0] & 0x0F);
         if (stored_token_len == token_len) {
             uint8_t stored_token[8];
-            memcpy(stored_token, &stored_msg->send_msg_ptr->packet_ptr[4], stored_token_len);
+            memcpy(stored_token, &stored_msg->send_msg_ptr.packet_ptr[4], stored_token_len);
             if (memcmp(stored_token, token, stored_token_len) == 0) {
-                uint16_t temp_msg_id = (stored_msg->send_msg_ptr->packet_ptr[2] << 8);
-                temp_msg_id += (uint16_t)stored_msg->send_msg_ptr->packet_ptr[3];
+                uint16_t temp_msg_id = (stored_msg->send_msg_ptr.packet_ptr[2] << 8);
+                temp_msg_id += (uint16_t)stored_msg->send_msg_ptr.packet_ptr[3];
                 tr_debug("sn_coap_protocol_delete_retransmission_by_token - removed msg_id: %d", temp_msg_id);
                 ns_list_remove(&handle->linked_list_resent_msgs, stored_msg);
                 --handle->count_resent_msgs;
@@ -840,8 +840,8 @@ rescan:
                     coap_version_e coap_version = COAP_VERSION_UNKNOWN;
 
                     /* Get message ID from stored sending message */
-                    uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr->packet_ptr[2] << 8);
-                    temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr->packet_ptr[3];
+                    uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
+                    temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
 
                     /* Remove message from Linked list */
                     ns_list_remove(&handle->linked_list_resent_msgs, stored_msg_ptr);
@@ -851,11 +851,11 @@ rescan:
                     if (stored_msg_ptr->coap->sn_coap_rx_callback != 0) {
                         sn_coap_hdr_s *tmp_coap_hdr_ptr;
                         /* Parse CoAP message, set status and call RX callback */
-                        tmp_coap_hdr_ptr = sn_coap_parser(stored_msg_ptr->coap, stored_msg_ptr->send_msg_ptr->packet_len, stored_msg_ptr->send_msg_ptr->packet_ptr, &coap_version);
+                        tmp_coap_hdr_ptr = sn_coap_parser(stored_msg_ptr->coap, stored_msg_ptr->send_msg_ptr.packet_len, stored_msg_ptr->send_msg_ptr.packet_ptr, &coap_version);
 
                         if (tmp_coap_hdr_ptr != 0) {
                             tmp_coap_hdr_ptr->coap_status = COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED;
-                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, stored_msg_ptr->send_msg_ptr->dst_addr_ptr, stored_msg_ptr->param);
+                            stored_msg_ptr->coap->sn_coap_rx_callback(tmp_coap_hdr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                             sn_coap_parser_release_allocated_coap_msg_mem(stored_msg_ptr->coap, tmp_coap_hdr_ptr);
                         }
@@ -865,8 +865,8 @@ rescan:
                     sn_coap_protocol_release_allocated_send_msg_mem(handle, stored_msg_ptr);
                 } else {
                     /* Send message  */
-                    stored_msg_ptr->coap->sn_coap_tx_callback(stored_msg_ptr->send_msg_ptr->packet_ptr,
-                            stored_msg_ptr->send_msg_ptr->packet_len, stored_msg_ptr->send_msg_ptr->dst_addr_ptr, stored_msg_ptr->param);
+                    stored_msg_ptr->coap->sn_coap_tx_callback(stored_msg_ptr->send_msg_ptr.packet_ptr,
+                            stored_msg_ptr->send_msg_ptr.packet_len, stored_msg_ptr->send_msg_ptr.dst_addr_ptr, stored_msg_ptr->param);
 
                     /* * * Count new Resending time  * * */
                     stored_msg_ptr->resending_time = sn_coap_calculate_new_resend_time(current_time,
@@ -944,15 +944,15 @@ static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle
     stored_msg_ptr->resending_time = sending_time;
 
     /* Filling of sn_nsdl_transmit_s */
-    stored_msg_ptr->send_msg_ptr->protocol = SN_NSDL_PROTOCOL_COAP;
-    stored_msg_ptr->send_msg_ptr->packet_len = send_packet_data_len;
-    memcpy(stored_msg_ptr->send_msg_ptr->packet_ptr, send_packet_data_ptr, send_packet_data_len);
+    stored_msg_ptr->send_msg_ptr.protocol = SN_NSDL_PROTOCOL_COAP;
+    stored_msg_ptr->send_msg_ptr.packet_len = send_packet_data_len;
+    memcpy(stored_msg_ptr->send_msg_ptr.packet_ptr, send_packet_data_ptr, send_packet_data_len);
 
     /* Filling of sn_nsdl_addr_s */
-    stored_msg_ptr->send_msg_ptr->dst_addr_ptr->type = dst_addr_ptr->type;
-    stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_len = dst_addr_ptr->addr_len;
-    memcpy(stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
-    stored_msg_ptr->send_msg_ptr->dst_addr_ptr->port = dst_addr_ptr->port;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->type = dst_addr_ptr->type;
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_len = dst_addr_ptr->addr_len;
+    memcpy(stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_ptr, dst_addr_ptr->addr_len);
+    stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port = dst_addr_ptr->port;
 
     stored_msg_ptr->coap = handle;
     stored_msg_ptr->param = param;
@@ -982,17 +982,17 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
     /* Loop all stored resending messages Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
         /* Get message ID from stored resending message */
-        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr->packet_ptr[2] << 8);
-        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr->packet_ptr[3];
+        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
+        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr->dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
                     /* * * Message found, return pointer to that stored resending message * * * */
-                    return stored_msg_ptr->send_msg_ptr;
+                    return &stored_msg_ptr->send_msg_ptr;
                 }
             }
         }
@@ -1015,15 +1015,15 @@ static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, 
     /* Loop all stored resending messages in Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
         /* Get message ID from stored resending message */
-        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr->packet_ptr[2] << 8);
-        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr->packet_ptr[3];
+        uint16_t temp_msg_id = (stored_msg_ptr->send_msg_ptr.packet_ptr[2] << 8);
+        temp_msg_id += (uint16_t)stored_msg_ptr->send_msg_ptr.packet_ptr[3];
 
         /* If message's Message ID is same than is searched */
         if (temp_msg_id == msg_id) {
             /* If message's Source address is same than is searched */
-            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
+            if (0 == memcmp(src_addr_ptr->addr_ptr, stored_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, src_addr_ptr->addr_len)) {
                 /* If message's Source address port is same than is searched */
-                if (stored_msg_ptr->send_msg_ptr->dst_addr_ptr->port == src_addr_ptr->port) {
+                if (stored_msg_ptr->send_msg_ptr.dst_addr_ptr->port == src_addr_ptr->port) {
                     /* * * Message found * * */
 
                     /* Remove message from Linked list */
@@ -1590,39 +1590,30 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 
     memset(msg_ptr, 0, sizeof(coap_send_msg_s));
 
-    msg_ptr->send_msg_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_transmit_s));
+    msg_ptr->send_msg_ptr.dst_addr_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
 
-    if (msg_ptr->send_msg_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.dst_addr_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    memset(msg_ptr->send_msg_ptr, 0 , sizeof(sn_nsdl_transmit_s));
+    memset(msg_ptr->send_msg_ptr.dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
 
-    msg_ptr->send_msg_ptr->dst_addr_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
+    msg_ptr->send_msg_ptr.packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
 
-    if (msg_ptr->send_msg_ptr->dst_addr_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.packet_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    memset(msg_ptr->send_msg_ptr->dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
+    msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
 
-    msg_ptr->send_msg_ptr->packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
-
-    if (msg_ptr->send_msg_ptr->packet_ptr == NULL) {
+    if (msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr == NULL) {
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
 
-    msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
-
-    if (msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr == NULL) {
-        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
-        return 0;
-    }
-
-    memset(msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, 0, dst_addr_ptr->addr_len);
+    memset(msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr, 0, dst_addr_ptr->addr_len);
 
     return msg_ptr;
 }
@@ -1639,18 +1630,15 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr)
 {
     if (freed_send_msg_ptr != NULL) {
-        if (freed_send_msg_ptr->send_msg_ptr != NULL) {
-            if (freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr != NULL) {
+        if (freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr != NULL) {
 
-                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr);
+            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr->addr_ptr);
 
-                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr);
-            }
-
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->packet_ptr);
-
-            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr);
+            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.dst_addr_ptr);
         }
+
+        handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr.packet_ptr);
+
 
         handle->sn_coap_protocol_free(freed_send_msg_ptr);
     }
@@ -1668,9 +1656,7 @@ static uint16_t sn_coap_count_linked_list_size(const coap_send_msg_list_t *linke
     uint16_t total_size = 0;
 
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, linked_list_ptr) {
-        if (stored_msg_ptr->send_msg_ptr) {
-            total_size += stored_msg_ptr->send_msg_ptr->packet_len;
-        }
+        total_size += stored_msg_ptr->send_msg_ptr.packet_len;
     }
 
     return total_size;

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -520,13 +520,12 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
 
         coap_blockwise_msg_s *stored_blockwise_msg_ptr;
 
-        stored_blockwise_msg_ptr = handle->sn_coap_protocol_malloc(sizeof(coap_blockwise_msg_s));
+        stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
         if (!stored_blockwise_msg_ptr) {
             //block paylaod save failed, only first block can be build. Perhaps we should return error.
             tr_error("sn_coap_protocol_build - blockwise message allocation failed!");
             return byte_count_built;
         }
-        memset(stored_blockwise_msg_ptr, 0, sizeof(coap_blockwise_msg_s));
 
         /* Fill struct */
         stored_blockwise_msg_ptr->timestamp = handle->system_time;
@@ -558,12 +557,11 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         /* Add message to linked list - response can be in blocks and we need header to build response.. */
         coap_blockwise_msg_s *stored_blockwise_msg_ptr;
 
-        stored_blockwise_msg_ptr = handle->sn_coap_protocol_malloc(sizeof(coap_blockwise_msg_s));
+        stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
         if (!stored_blockwise_msg_ptr) {
             tr_error("sn_coap_protocol_build - blockwise (GET) allocation failed!");
             return byte_count_built;
         }
-        memset(stored_blockwise_msg_ptr, 0, sizeof(coap_blockwise_msg_s));
 
         /* Fill struct */
         stored_blockwise_msg_ptr->timestamp = handle->system_time;
@@ -1092,22 +1090,20 @@ static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *h
     /* * * * Allocating memory for stored Duplication info * * * */
 
     /* Allocate memory for stored Duplication info's structure */
-    stored_duplication_info_ptr = handle->sn_coap_protocol_malloc(sizeof(coap_duplication_info_s));
+    stored_duplication_info_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_duplication_info_s));
 
     if (stored_duplication_info_ptr == NULL) {
         tr_error("sn_coap_protocol_linked_list_duplication_info_store - failed to allocate duplication info!");
         return;
     }
-    memset(stored_duplication_info_ptr, 0, sizeof(coap_duplication_info_s));
 
     /* Allocate memory for stored Duplication info's address */
-    stored_duplication_info_ptr->address = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
+    stored_duplication_info_ptr->address = sn_coap_protocol_calloc(handle, sizeof(sn_nsdl_addr_s));
     if (stored_duplication_info_ptr->address == NULL) {
         tr_error("sn_coap_protocol_linked_list_duplication_info_store - failed to allocate address!");
         handle->sn_coap_protocol_free(stored_duplication_info_ptr);
         return;
     }
-    memset(stored_duplication_info_ptr->address, 0, sizeof(sn_nsdl_addr_s));
 
     stored_duplication_info_ptr->address->addr_ptr = handle->sn_coap_protocol_malloc(addr_ptr->addr_len);
 
@@ -1579,17 +1575,15 @@ rescan:
 coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t packet_data_len)
 {
 
-    coap_send_msg_s *msg_ptr = handle->sn_coap_protocol_malloc(sizeof(coap_send_msg_s));
+    coap_send_msg_s *msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_send_msg_s));
 
     if (msg_ptr == NULL) {
         return 0;
     }
 
-    memset(msg_ptr, 0, sizeof(coap_send_msg_s));
-
     msg_ptr->send_msg_ptr.packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
 
-    msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
+    msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr = sn_coap_protocol_calloc(handle, dst_addr_ptr->addr_len);
 
     if ((msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr == NULL) ||
         (msg_ptr->send_msg_ptr.packet_ptr == NULL)) {
@@ -1597,8 +1591,6 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
-
-    memset(msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr, 0, dst_addr_ptr->addr_len);
 
     return msg_ptr;
 }
@@ -2111,7 +2103,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     dst_packed_data_needed_mem = sn_coap_builder_calc_needed_packet_data_size_2(src_coap_blockwise_ack_msg_ptr ,handle->sn_coap_block_data_size);
 
                     /* Then allocate memory for Packet data */
-                    dst_ack_packet_data_ptr = handle->sn_coap_protocol_malloc(dst_packed_data_needed_mem);
+                    dst_ack_packet_data_ptr = sn_coap_protocol_calloc(handle, dst_packed_data_needed_mem);
 
                     if (dst_ack_packet_data_ptr == NULL) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate packet!");
@@ -2119,7 +2111,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
-                    memset(dst_ack_packet_data_ptr, 0, dst_packed_data_needed_mem);
 
                     /* * * Then build Acknowledgement message to Packed data * * */
                     if ((sn_coap_builder_2(dst_ack_packet_data_ptr, src_coap_blockwise_ack_msg_ptr, handle->sn_coap_block_data_size)) < 0) {
@@ -2134,7 +2125,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     /* * * Save to linked list * * */
                     coap_blockwise_msg_s *stored_blockwise_msg_ptr;
 
-                    stored_blockwise_msg_ptr = handle->sn_coap_protocol_malloc(sizeof(coap_blockwise_msg_s));
+                    stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
                     if (!stored_blockwise_msg_ptr) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate blockwise message!");
                         handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
@@ -2142,7 +2133,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return 0;
                     }
-                    memset(stored_blockwise_msg_ptr, 0, sizeof(coap_blockwise_msg_s));
 
                     stored_blockwise_msg_ptr->timestamp = handle->system_time;
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -753,16 +753,8 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
             }
         }
         if (remove_from_the_list) {
-            ns_list_remove(&handle->linked_list_blockwise_sent_msgs, stored_blockwise_msg_temp_ptr);
-            if (stored_blockwise_msg_temp_ptr->coap_msg_ptr) {
-                if(stored_blockwise_msg_temp_ptr->coap_msg_ptr->payload_ptr){
-                    handle->sn_coap_protocol_free(stored_blockwise_msg_temp_ptr->coap_msg_ptr->payload_ptr);
-                    stored_blockwise_msg_temp_ptr->coap_msg_ptr->payload_ptr = 0;
-                }
-                sn_coap_parser_release_allocated_coap_msg_mem(stored_blockwise_msg_temp_ptr->coap, stored_blockwise_msg_temp_ptr->coap_msg_ptr);
-            }
 
-            handle->sn_coap_protocol_free(stored_blockwise_msg_temp_ptr);
+            sn_coap_protocol_linked_list_blockwise_msg_remove(handle, stored_blockwise_msg_temp_ptr);
         }
     }
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -1621,34 +1621,44 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
     coap_send_msg_s *msg_ptr = handle->sn_coap_protocol_malloc(sizeof(coap_send_msg_s));
 
     if (msg_ptr == NULL) {
-        return NULL;
+        return 0;
     }
 
-    //Locall structure for 1 malloc for send msg
-    struct
-    {
-        sn_nsdl_transmit_s transmit;
-        sn_nsdl_addr_s addr;
-        uint8_t trail_data[];
-    } *m;
-    int trail_size = dst_addr_ptr->addr_len + packet_data_len;
-
-    m = handle->sn_coap_protocol_malloc(sizeof *m + trail_size);
-    if (!m) {
-        handle->sn_coap_protocol_free(msg_ptr);
-        return NULL;
-    }
-    //Init data
-    memset(m, 0, sizeof(*m) + trail_size);
     memset(msg_ptr, 0, sizeof(coap_send_msg_s));
 
-    msg_ptr->send_msg_ptr = &m->transmit;
-    msg_ptr->send_msg_ptr->dst_addr_ptr = &m->addr;
+    msg_ptr->send_msg_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_transmit_s));
 
-    msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr = m->trail_data;
-    if (packet_data_len) {
-        msg_ptr->send_msg_ptr->packet_ptr = m->trail_data + dst_addr_ptr->addr_len;
+    if (msg_ptr->send_msg_ptr == NULL) {
+        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
+        return 0;
     }
+
+    memset(msg_ptr->send_msg_ptr, 0 , sizeof(sn_nsdl_transmit_s));
+
+    msg_ptr->send_msg_ptr->dst_addr_ptr = handle->sn_coap_protocol_malloc(sizeof(sn_nsdl_addr_s));
+
+    if (msg_ptr->send_msg_ptr->dst_addr_ptr == NULL) {
+        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
+        return 0;
+    }
+
+    memset(msg_ptr->send_msg_ptr->dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
+
+    msg_ptr->send_msg_ptr->packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
+
+    if (msg_ptr->send_msg_ptr->packet_ptr == NULL) {
+        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
+        return 0;
+    }
+
+    msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
+
+    if (msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr == NULL) {
+        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
+        return 0;
+    }
+
+    memset(msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr, 0, dst_addr_ptr->addr_len);
 
     return msg_ptr;
 }
@@ -1665,8 +1675,26 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr)
 {
     if (freed_send_msg_ptr != NULL) {
-        handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr);
-        freed_send_msg_ptr->send_msg_ptr = NULL;
+        if (freed_send_msg_ptr->send_msg_ptr != NULL) {
+            if (freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr != NULL) {
+                if (freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr != NULL) {
+                    handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr);
+                    freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr->addr_ptr = 0;
+                }
+
+                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr);
+                freed_send_msg_ptr->send_msg_ptr->dst_addr_ptr = 0;
+            }
+
+            if (freed_send_msg_ptr->send_msg_ptr->packet_ptr != NULL) {
+                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->packet_ptr);
+                freed_send_msg_ptr->send_msg_ptr->packet_ptr = 0;
+            }
+
+            handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr);
+            freed_send_msg_ptr->send_msg_ptr = 0;
+        }
+
         handle->sn_coap_protocol_free(freed_send_msg_ptr);
         freed_send_msg_ptr = NULL;
     }

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -709,7 +709,17 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
     if (returned_dst_coap_msg_ptr->options_list_ptr != NULL &&
             (returned_dst_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE ||
              returned_dst_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE)) {
-        returned_dst_coap_msg_ptr = sn_coap_handle_blockwise_message(handle, src_addr_ptr, returned_dst_coap_msg_ptr, param);
+
+        // the sn_coap_handle_blockwise_message() will return the given message on success or NULL on error
+        if (sn_coap_handle_blockwise_message(handle, src_addr_ptr, returned_dst_coap_msg_ptr, param) == NULL) {
+
+            tr_error("sn_coap_protocol_parse - handle blockwise returns null!");
+
+            // the message is freed just here, not in every other path in sn_coap_handle_blockwise_message().
+            sn_coap_parser_release_allocated_coap_msg_mem(handle, returned_dst_coap_msg_ptr);
+            returned_dst_coap_msg_ptr = NULL;
+        }
+
     } else if (returned_dst_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY) {
         // Do not clean stored blockwise message when empty ack is received.
         // Stored message is mandatory when building a next (GET) blockwise message.
@@ -1669,7 +1679,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     } else {
                         if (!sn_coap_parser_alloc_options(handle, src_coap_blockwise_ack_msg_ptr)) {
                             tr_error("sn_coap_handle_blockwise_message - (send block1) failed to allocate ack message!");
-                            sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                             return 0;
                         }
                     }
@@ -1703,7 +1712,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         handle->sn_coap_protocol_free(original_payload_ptr);
                         handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
                         stored_blockwise_msg_temp_ptr->coap_msg_ptr = NULL;
-                        sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
                     src_coap_blockwise_ack_msg_ptr->msg_id = get_new_message_id();
@@ -1775,14 +1783,12 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 src_coap_blockwise_ack_msg_ptr = sn_coap_parser_alloc_message(handle);
                 if (src_coap_blockwise_ack_msg_ptr == NULL) {
                     tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate ack message!");
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                     return NULL;
                 }
 
                 if (sn_coap_parser_alloc_options(handle, src_coap_blockwise_ack_msg_ptr) == NULL) {
                    tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate options!");
                     handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                     return NULL;
                 }
 
@@ -1839,7 +1845,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 dst_ack_packet_data_ptr = handle->sn_coap_protocol_malloc(dst_packed_data_needed_mem);
                 if (!dst_ack_packet_data_ptr) {
                     tr_error("sn_coap_handle_blockwise_message - (recv block1) message allocation failed!");
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                     handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->options_list_ptr);
                     handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
                     return NULL;
@@ -1880,7 +1885,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 temp_whole_payload_ptr = handle->sn_coap_protocol_malloc(whole_payload_len);
                 if (temp_whole_payload_ptr == NULL || whole_payload_len > UINT16_MAX) {
                     tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate all blocks!");
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                     handle->sn_coap_protocol_free(temp_whole_payload_ptr);
                     return 0;
                 }
@@ -1929,7 +1933,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                     if (!previous_blockwise_msg_ptr || !previous_blockwise_msg_ptr->coap_msg_ptr) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) previous message null!");
-                        sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return 0;
                     }
 
@@ -1945,7 +1948,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate options!");
                         handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
                         src_coap_blockwise_ack_msg_ptr = 0;
-                        sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
 
@@ -1996,7 +1998,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     if (dst_ack_packet_data_ptr == NULL) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate packet!");
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
-                        sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
 
@@ -2005,7 +2006,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         tr_error("sn_coap_handle_blockwise_message - (send block2) builder failed!");
                         handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
-                        sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
 
@@ -2017,7 +2017,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate blockwise message!");
                         handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
-                        sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return 0;
                     }
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -65,9 +65,10 @@ static void                  sn_coap_protocol_linked_list_blockwise_payload_remo
 static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len);
 static void                  sn_coap_protocol_handle_blockwise_timout(struct coap_s *handle);
 static sn_coap_hdr_s        *sn_coap_handle_blockwise_message(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr, void *param);
+static bool                  sn_coap_handle_last_blockwise(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr);
 static sn_coap_hdr_s        *sn_coap_protocol_copy_header(struct coap_s *handle, const sn_coap_hdr_s *source_header_ptr);
 static coap_blockwise_msg_s *search_sent_blockwise_message(struct coap_s *handle, uint16_t msg_id);
-static int16_t              store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *src_coap_msg_ptr, void *param, bool copy_payload);
+static int16_t               store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *src_coap_msg_ptr, void *param, bool copy_payload);
 #endif
 
 #if ENABLE_RESENDINGS
@@ -1870,31 +1871,10 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 /* * * This is the last block when whole Blockwise payload from received * * */
                 /* * * blockwise messages is gathered and returned to User               * * */
 
-                /* Store last Blockwise payload to Linked list */
-                uint16_t payload_len            = 0;
-                uint8_t *payload_ptr            = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                uint32_t whole_payload_len      = sn_coap_protocol_linked_list_blockwise_payloads_get_len(handle, src_addr_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                uint8_t *temp_whole_payload_ptr = NULL;
+                if (!sn_coap_handle_last_blockwise(handle, src_addr_ptr, received_coap_msg_ptr)) {
 
-                temp_whole_payload_ptr = handle->sn_coap_protocol_malloc(whole_payload_len);
-                if (temp_whole_payload_ptr == NULL || whole_payload_len > UINT16_MAX) {
-                    tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate all blocks!");
-                    handle->sn_coap_protocol_free(temp_whole_payload_ptr);
-                    return 0;
+                    return NULL;
                 }
-
-                // In block message case, payload_ptr freeing must be done in application level
-                received_coap_msg_ptr->payload_ptr = temp_whole_payload_ptr;
-                received_coap_msg_ptr->payload_len = whole_payload_len;
-
-                /* Copy stored Blockwise payloads to returned whole Blockwise payload pointer */
-                while (payload_ptr != NULL) {
-                    memcpy(temp_whole_payload_ptr, payload_ptr, payload_len);
-                    temp_whole_payload_ptr += payload_len;
-                    sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                    payload_ptr = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                }
-                received_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED;
             }
         }
     }
@@ -2033,31 +2013,10 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     /* * * This is the last block when whole Blockwise payload from received * * */
                     /* * * blockwise messages is gathered and returned to User               * * */
 
-                    /* Store last Blockwise payload to Linked list */
-                    uint16_t payload_len            = 0;
-                    uint8_t *payload_ptr            = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                    uint16_t whole_payload_len      = sn_coap_protocol_linked_list_blockwise_payloads_get_len(handle, src_addr_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                    uint8_t *temp_whole_payload_ptr = NULL;
+                    if (!sn_coap_handle_last_blockwise(handle, src_addr_ptr, received_coap_msg_ptr)) {
 
-                    temp_whole_payload_ptr = handle->sn_coap_protocol_malloc(whole_payload_len);
-                    if (!temp_whole_payload_ptr) {
-                        tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate whole payload!");
-                        return 0;
+                        return NULL;
                     }
-
-                    received_coap_msg_ptr->payload_ptr = temp_whole_payload_ptr;
-                    received_coap_msg_ptr->payload_len = whole_payload_len;
-
-                    /* Copy stored Blockwise payloads to returned whole Blockwise payload pointer */
-                    while (payload_ptr != NULL) {
-                        memcpy(temp_whole_payload_ptr, payload_ptr, payload_len);
-
-                        temp_whole_payload_ptr += payload_len;
-
-                        sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                        payload_ptr = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                    }
-                    received_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED;
 
                     //todo: remove previous msg from list
                 }
@@ -2166,6 +2125,37 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
         }
     }
     return received_coap_msg_ptr;
+}
+
+static bool sn_coap_handle_last_blockwise(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr)
+{
+    /* Store last Blockwise payload to Linked list */
+    uint16_t payload_len            = 0;
+    uint8_t *payload_ptr            = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+    uint32_t whole_payload_len      = sn_coap_protocol_linked_list_blockwise_payloads_get_len(handle, src_addr_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+    uint8_t *temp_whole_payload_ptr = NULL;
+
+    temp_whole_payload_ptr = handle->sn_coap_protocol_malloc(whole_payload_len);
+    if (temp_whole_payload_ptr == NULL || whole_payload_len > UINT16_MAX) {
+        tr_error("sn_coap_handle_blockwise_message - (recv block) failed to allocate all blocks, len: %" PRIu32, whole_payload_len);
+        handle->sn_coap_protocol_free(temp_whole_payload_ptr);
+        return false;
+    }
+
+    // In block message case, payload_ptr freeing must be done in application level
+    received_coap_msg_ptr->payload_ptr = temp_whole_payload_ptr;
+    received_coap_msg_ptr->payload_len = whole_payload_len;
+
+    /* Copy stored Blockwise payloads to returned whole Blockwise payload pointer */
+    while (payload_ptr != NULL) {
+        memcpy(temp_whole_payload_ptr, payload_ptr, payload_len);
+        temp_whole_payload_ptr += payload_len;
+        sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+        payload_ptr = sn_coap_protocol_linked_list_blockwise_payload_search(handle, src_addr_ptr, &payload_len, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+    }
+    received_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED;
+
+    return true;
 }
 
 int8_t sn_coap_convert_block_size(uint16_t block_size)

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -2362,75 +2362,78 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, const 
             return 0;
         }
 
-        destination_header_ptr->options_list_ptr->max_age = source_header_ptr->options_list_ptr->max_age;
+        const sn_coap_options_list_s *source_options_list_ptr = source_header_ptr->options_list_ptr;
+        sn_coap_options_list_s *destination_options_list_ptr = destination_header_ptr->options_list_ptr;
 
-        if (source_header_ptr->options_list_ptr->proxy_uri_ptr) {
-            destination_header_ptr->options_list_ptr->proxy_uri_len = source_header_ptr->options_list_ptr->proxy_uri_len;
-            destination_header_ptr->options_list_ptr->proxy_uri_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->proxy_uri_ptr, source_header_ptr->options_list_ptr->proxy_uri_len);
-            if (!destination_header_ptr->options_list_ptr->proxy_uri_ptr) {
+        destination_options_list_ptr->max_age = source_options_list_ptr->max_age;
+
+        if (source_options_list_ptr->proxy_uri_ptr) {
+            destination_options_list_ptr->proxy_uri_len = source_options_list_ptr->proxy_uri_len;
+            destination_options_list_ptr->proxy_uri_ptr = sn_coap_protocol_malloc_copy(handle, source_options_list_ptr->proxy_uri_ptr, source_options_list_ptr->proxy_uri_len);
+            if (!destination_options_list_ptr->proxy_uri_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate proxy uri!");
                 return 0;
             }
         }
 
-        if (source_header_ptr->options_list_ptr->etag_ptr) {
-            destination_header_ptr->options_list_ptr->etag_len = source_header_ptr->options_list_ptr->etag_len;
-            destination_header_ptr->options_list_ptr->etag_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->etag_ptr, source_header_ptr->options_list_ptr->etag_len);
-            if (!destination_header_ptr->options_list_ptr->etag_ptr) {
+        if (source_options_list_ptr->etag_ptr) {
+            destination_options_list_ptr->etag_len = source_options_list_ptr->etag_len;
+            destination_options_list_ptr->etag_ptr = sn_coap_protocol_malloc_copy(handle, source_options_list_ptr->etag_ptr, source_options_list_ptr->etag_len);
+            if (!destination_options_list_ptr->etag_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate etag!");
                 return 0;
             }
         }
 
-        if (source_header_ptr->options_list_ptr->uri_host_ptr) {
-            destination_header_ptr->options_list_ptr->uri_host_len = source_header_ptr->options_list_ptr->uri_host_len;
-            destination_header_ptr->options_list_ptr->uri_host_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->uri_host_ptr, source_header_ptr->options_list_ptr->uri_host_len);
-            if (!destination_header_ptr->options_list_ptr->uri_host_ptr) {
+        if (source_options_list_ptr->uri_host_ptr) {
+            destination_options_list_ptr->uri_host_len = source_options_list_ptr->uri_host_len;
+            destination_options_list_ptr->uri_host_ptr = sn_coap_protocol_malloc_copy(handle, source_options_list_ptr->uri_host_ptr, source_options_list_ptr->uri_host_len);
+            if (!destination_options_list_ptr->uri_host_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate uri host!");
                 return 0;
             }
         }
 
-        if (source_header_ptr->options_list_ptr->location_path_ptr) {
-            destination_header_ptr->options_list_ptr->location_path_len = source_header_ptr->options_list_ptr->location_path_len;
-            destination_header_ptr->options_list_ptr->location_path_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->location_path_ptr, source_header_ptr->options_list_ptr->location_path_len);
-            if (!destination_header_ptr->options_list_ptr->location_path_ptr) {
+        if (source_options_list_ptr->location_path_ptr) {
+            destination_options_list_ptr->location_path_len = source_options_list_ptr->location_path_len;
+            destination_options_list_ptr->location_path_ptr = sn_coap_protocol_malloc_copy(handle, source_options_list_ptr->location_path_ptr, source_options_list_ptr->location_path_len);
+            if (!destination_options_list_ptr->location_path_ptr) {
                 tr_error("sn_coap_protocol_copy_header - failed to allocate location path!");
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 return 0;
             }
         }
 
-        destination_header_ptr->options_list_ptr->uri_port = source_header_ptr->options_list_ptr->uri_port;
+        destination_options_list_ptr->uri_port = source_options_list_ptr->uri_port;
 
-        if (source_header_ptr->options_list_ptr->location_query_ptr) {
-            destination_header_ptr->options_list_ptr->location_query_len = source_header_ptr->options_list_ptr->location_query_len;
-            destination_header_ptr->options_list_ptr->location_query_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->location_query_ptr, source_header_ptr->options_list_ptr->location_query_len);
-            if (!destination_header_ptr->options_list_ptr->location_query_ptr) {
+        if (source_options_list_ptr->location_query_ptr) {
+            destination_options_list_ptr->location_query_len = source_options_list_ptr->location_query_len;
+            destination_options_list_ptr->location_query_ptr = sn_coap_protocol_malloc_copy(handle, source_options_list_ptr->location_query_ptr, source_options_list_ptr->location_query_len);
+            if (!destination_options_list_ptr->location_query_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate location query!");
                 return 0;
             }
         }
 
-        destination_header_ptr->options_list_ptr->observe = source_header_ptr->options_list_ptr->observe;
-        destination_header_ptr->options_list_ptr->accept = source_header_ptr->options_list_ptr->accept;
+        destination_options_list_ptr->observe = source_options_list_ptr->observe;
+        destination_options_list_ptr->accept = source_options_list_ptr->accept;
 
-        if (source_header_ptr->options_list_ptr->uri_query_ptr) {
-            destination_header_ptr->options_list_ptr->uri_query_len = source_header_ptr->options_list_ptr->uri_query_len;
-            destination_header_ptr->options_list_ptr->uri_query_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->uri_query_ptr, source_header_ptr->options_list_ptr->uri_query_len);
-            if (!destination_header_ptr->options_list_ptr->uri_query_ptr) {
+        if (source_options_list_ptr->uri_query_ptr) {
+            destination_options_list_ptr->uri_query_len = source_options_list_ptr->uri_query_len;
+            destination_options_list_ptr->uri_query_ptr = sn_coap_protocol_malloc_copy(handle, source_options_list_ptr->uri_query_ptr, source_options_list_ptr->uri_query_len);
+            if (!destination_options_list_ptr->uri_query_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate uri query!");
                 return 0;
             }
         }
 
-        destination_header_ptr->options_list_ptr->block1 = source_header_ptr->options_list_ptr->block1;
-        destination_header_ptr->options_list_ptr->block2 = source_header_ptr->options_list_ptr->block2;
+        destination_options_list_ptr->block1 = source_options_list_ptr->block1;
+        destination_options_list_ptr->block2 = source_options_list_ptr->block2;
     }
 
     return destination_header_ptr;

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -67,6 +67,7 @@ static void                  sn_coap_protocol_handle_blockwise_timout(struct coa
 static sn_coap_hdr_s        *sn_coap_handle_blockwise_message(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr, void *param);
 static sn_coap_hdr_s        *sn_coap_protocol_copy_header(struct coap_s *handle, const sn_coap_hdr_s *source_header_ptr);
 static coap_blockwise_msg_s *search_sent_blockwise_message(struct coap_s *handle, uint16_t msg_id);
+static int16_t              store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *src_coap_msg_ptr, void *param, bool copy_payload);
 #endif
 
 #if ENABLE_RESENDINGS
@@ -496,8 +497,6 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
 
-    // TODO: COMBINE THESE TWO BRANCHES
-
     /* If blockwising needed */
     if ((original_payload_len > handle->sn_coap_block_data_size) && (handle->sn_coap_block_data_size > 0)) {
 
@@ -505,63 +504,18 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         /* * * * Manage rest blockwise messages sending by storing them to Linked list * * * */
         /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-        coap_blockwise_msg_s *stored_blockwise_msg_ptr;
-
-        stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
-        if (!stored_blockwise_msg_ptr) {
-            //block paylaod save failed, only first block can be build. Perhaps we should return error.
-            tr_error("sn_coap_protocol_build - blockwise message allocation failed!");
-            return byte_count_built;
+        int status = store_blockwise_copy(handle, src_coap_msg_ptr, param, true);
+        if (status < 0) {
+            return status;
         }
 
-        /* Fill struct */
-        stored_blockwise_msg_ptr->timestamp = handle->system_time;
-
-        stored_blockwise_msg_ptr->coap_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
-        if( stored_blockwise_msg_ptr->coap_msg_ptr == NULL ){
-            handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
-            tr_error("sn_coap_protocol_build - block header copy failed!");
-            return -2;
-        }
-
-        stored_blockwise_msg_ptr->coap_msg_ptr->payload_len = original_payload_len;
-        stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr = sn_coap_protocol_malloc_copy(handle, src_coap_msg_ptr->payload_ptr, stored_blockwise_msg_ptr->coap_msg_ptr->payload_len);
-
-        if (!stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr) {
-            //block payload save failed, only first block can be build. Perhaps we should return error.
-            sn_coap_parser_release_allocated_coap_msg_mem(handle, stored_blockwise_msg_ptr->coap_msg_ptr);
-            handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
-            tr_error("sn_coap_protocol_build - block payload allocation failed!");
-            return byte_count_built;
-        }
-
-        stored_blockwise_msg_ptr->param = param;
-        stored_blockwise_msg_ptr->msg_id = stored_blockwise_msg_ptr->coap_msg_ptr->msg_id;
-        ns_list_add_to_end(&handle->linked_list_blockwise_sent_msgs, stored_blockwise_msg_ptr);
     } else if (src_coap_msg_ptr->msg_code <= COAP_MSG_CODE_REQUEST_DELETE &&
                src_coap_msg_ptr->msg_code != COAP_MSG_CODE_EMPTY) {
-        /* Add message to linked list - response can be in blocks and we need header to build response.. */
-        coap_blockwise_msg_s *stored_blockwise_msg_ptr;
 
-        stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
-        if (!stored_blockwise_msg_ptr) {
-            tr_error("sn_coap_protocol_build - blockwise (GET) allocation failed!");
-            return byte_count_built;
+        int status = store_blockwise_copy(handle, src_coap_msg_ptr, param, false);
+        if (status < 0) {
+            return status;
         }
-
-        /* Fill struct */
-        stored_blockwise_msg_ptr->timestamp = handle->system_time;
-
-        stored_blockwise_msg_ptr->coap_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
-        if( stored_blockwise_msg_ptr->coap_msg_ptr == NULL ){
-            handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
-            tr_error("sn_coap_protocol_build - blockwise (GET) copy header failed!");
-            return -2;
-        }
-
-        stored_blockwise_msg_ptr->param = param;
-        stored_blockwise_msg_ptr->msg_id = stored_blockwise_msg_ptr->coap_msg_ptr->msg_id;
-        ns_list_add_to_end(&handle->linked_list_blockwise_sent_msgs, stored_blockwise_msg_ptr);
     }
 
 #endif /* SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE */
@@ -569,6 +523,49 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
     /* * * * Return built CoAP message Packet data length  * * * */
     return byte_count_built;
 }
+
+#if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *src_coap_msg_ptr, void *param, bool copy_payload)
+{
+    coap_blockwise_msg_s *stored_blockwise_msg_ptr;
+
+    stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
+    if (!stored_blockwise_msg_ptr) {
+        //block payload save failed, only first block can be build. Perhaps we should return error.
+        tr_error("sn_coap_protocol_build - blockwise message allocation failed!");
+        return -2;
+    }
+
+    /* Fill struct */
+    stored_blockwise_msg_ptr->timestamp = handle->system_time;
+
+    stored_blockwise_msg_ptr->coap_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
+    if( stored_blockwise_msg_ptr->coap_msg_ptr == NULL ){
+        handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
+        tr_error("sn_coap_protocol_build - block header copy failed!");
+        return -2;
+    }
+
+    if (copy_payload) {
+        stored_blockwise_msg_ptr->coap_msg_ptr->payload_len = src_coap_msg_ptr->payload_len;
+        stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr = sn_coap_protocol_malloc_copy(handle, src_coap_msg_ptr->payload_ptr, stored_blockwise_msg_ptr->coap_msg_ptr->payload_len);
+
+        if (!stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr) {
+            //block payload save failed, only first block can be build. Perhaps we should return error.
+            sn_coap_parser_release_allocated_coap_msg_mem(handle, stored_blockwise_msg_ptr->coap_msg_ptr);
+            handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
+            tr_error("sn_coap_protocol_build - block payload allocation failed!");
+            return -2;
+        }
+    }
+
+    stored_blockwise_msg_ptr->param = param;
+    stored_blockwise_msg_ptr->msg_id = stored_blockwise_msg_ptr->coap_msg_ptr->msg_id;
+    ns_list_add_to_end(&handle->linked_list_blockwise_sent_msgs, stored_blockwise_msg_ptr);
+
+    return 0;
+}
+#endif
 
 sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t packet_data_len, uint8_t *packet_data_ptr, void *param)
 {
@@ -1162,7 +1159,6 @@ static void sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *han
 
     if (removed_msg_ptr->coap_msg_ptr) {
         handle->sn_coap_protocol_free(removed_msg_ptr->coap_msg_ptr->payload_ptr);
-        removed_msg_ptr->coap_msg_ptr->payload_ptr = 0;
 
         sn_coap_parser_release_allocated_coap_msg_mem(handle, removed_msg_ptr->coap_msg_ptr);
     }
@@ -1742,7 +1738,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             } else {
                 // XXX what was this trying to free?
                 received_coap_msg_ptr->coap_status = COAP_STATUS_OK;
-
             }
         }
 
@@ -1776,6 +1771,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             /* If not last block (more value is set) */
             /* Block option length can be 1-3 bytes. First 4-20 bits are for block number. Last 4 bits are ALWAYS more bit + block size. */
             if (received_coap_msg_ptr->options_list_ptr->block1 & 0x08) {
+
                 src_coap_blockwise_ack_msg_ptr = sn_coap_parser_alloc_message(handle);
                 if (src_coap_blockwise_ack_msg_ptr == NULL) {
                     tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate ack message!");

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -665,7 +665,11 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
     if ((returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE ||
             returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_NON_CONFIRMABLE) &&
             handle->sn_coap_duplication_buffer_size != 0) {
-        if (sn_coap_protocol_linked_list_duplication_info_search(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id) == NULL) {
+
+        coap_duplication_info_s* response = sn_coap_protocol_linked_list_duplication_info_search(handle,
+                                                                                                 src_addr_ptr,
+                                                                                                 returned_dst_coap_msg_ptr->msg_id);
+        if (response == NULL) {
             /* * * No Message duplication: Store received message for detecting later duplication * * */
 
             /* Get count of stored duplication messages */
@@ -690,9 +694,7 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
         } else { /* * * Message duplication detected * * */
             /* Set returned status to User */
             returned_dst_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_DUPLICATED_MSG;
-            coap_duplication_info_s* response = sn_coap_protocol_linked_list_duplication_info_search(handle,
-                                                                                                     src_addr_ptr,
-                                                                                                     returned_dst_coap_msg_ptr->msg_id);
+
             /* Send ACK response */
             if (response) {
                 /* Check that response has been created */
@@ -768,15 +770,9 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
 
         /* Check if there is ongoing active message resendings */
         if (stored_resending_msgs_count > 0) {
-            sn_nsdl_transmit_s *removed_msg_ptr = NULL;
 
-            /* Check if received message was confirmation for some active resending message */
-            removed_msg_ptr = sn_coap_protocol_linked_list_send_msg_search(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id);
-
-            if (removed_msg_ptr != NULL) {
-                /* Remove resending message from active message resending Linked list */
-                sn_coap_protocol_linked_list_send_msg_remove(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id);
-            }
+            /* Remove resending message from active message resending Linked list, if any exists */
+            sn_coap_protocol_linked_list_send_msg_remove(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id);
         }
     }
 #endif /* ENABLE_RESENDINGS */
@@ -886,7 +882,7 @@ static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle
         uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param)
 {
 
-    coap_send_msg_s *stored_msg_ptr              = NULL;
+    coap_send_msg_s *stored_msg_ptr;
 
     /* If both queue parameters are "0" or resending count is "0", then re-sending is disabled */
     if (((handle->sn_coap_resending_queue_msgs == 0) && (handle->sn_coap_resending_queue_bytes == 0)) || (handle->sn_coap_resending_count == 0)) {
@@ -951,7 +947,8 @@ static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle
  * \return Return value is pointer to found stored resending message in Linked
  *         list or NULL if message not found
  *****************************************************************************/
-
+#if 0
+// this is getting unused
 static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct coap_s *handle,
         const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id)
 {
@@ -973,6 +970,8 @@ static sn_nsdl_transmit_s *sn_coap_protocol_linked_list_send_msg_search(struct c
     /* Message not found */
     return NULL;
 }
+#endif
+
 /**************************************************************************//**
  * \fn static void sn_coap_protocol_linked_list_send_msg_remove(sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id)
  *
@@ -1209,7 +1208,7 @@ static void sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *han
 {
     ns_list_remove(&handle->linked_list_blockwise_sent_msgs, removed_msg_ptr);
 
-    if( removed_msg_ptr->coap_msg_ptr ){
+    if (removed_msg_ptr->coap_msg_ptr) {
         handle->sn_coap_protocol_free(removed_msg_ptr->coap_msg_ptr->payload_ptr);
         removed_msg_ptr->coap_msg_ptr->payload_ptr = 0;
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -59,7 +59,7 @@ static bool                  sn_coap_protocol_update_duplicate_package_data(cons
 static void                  sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *handle, coap_blockwise_msg_s *removed_msg_ptr);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *handle, sn_nsdl_addr_s *addr_ptr, uint16_t stored_payload_len, uint8_t *stored_payload_ptr, uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
 static uint8_t              *sn_coap_protocol_linked_list_blockwise_payload_search(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t *payload_length, const uint8_t *token_ptr, uint8_t token_len);
-static bool                  sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, const uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
+static bool                  sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, const uint8_t *token_ptr, uint8_t token_len, uint32_t block_number);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s *handle, coap_blockwise_payload_s *removed_payload_ptr);
 static void                  sn_coap_protocol_linked_list_blockwise_payload_remove_oldest(struct coap_s *handle, uint8_t *token_ptr, uint8_t token_len);
 static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len);
@@ -1192,19 +1192,13 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
     }
 
     // Do not add duplicates to list, this could happen if server needs to retransmit block message again
-    ns_list_foreach(coap_blockwise_payload_s, payload_info_ptr, &handle->linked_list_blockwise_received_payloads) {
-        if ((0 == memcmp(addr_ptr->addr_ptr, payload_info_ptr->addr_ptr, addr_ptr->addr_len)) && (payload_info_ptr->port == addr_ptr->port)) {
-            if (token_ptr) {
-                if (!payload_info_ptr->token_ptr || (payload_info_ptr->token_len != token_len) || (memcmp(payload_info_ptr->token_ptr, token_ptr, token_len))) {
-                    continue;
-                }
-            } else if (payload_info_ptr->token_ptr) {
-                continue;
-            }
-            if (payload_info_ptr->block_number == block_number) {
-                return;
-            }
-        }
+
+    if (sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(handle,
+                                                                             addr_ptr,
+                                                                             token_ptr,
+                                                                             token_len,
+                                                                             block_number)) {
+        return;
     }
 
     coap_blockwise_payload_s *stored_blockwise_payload_ptr = NULL;
@@ -1305,7 +1299,7 @@ static uint8_t *sn_coap_protocol_linked_list_blockwise_payload_search(struct coa
     return NULL;
 }
 
-static bool sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(struct coap_s *handle,
+static bool sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(struct coap_s *handle,
                                                                                    const sn_nsdl_addr_s *src_addr_ptr,
                                                                                    const uint8_t *token_ptr,
                                                                                    uint8_t token_len,
@@ -1323,8 +1317,8 @@ static bool sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(
             } else if (stored_payload_info_ptr->token_ptr) {
                 continue;
             }
-            // Check that incoming block number matches to last received one
-            if (block_number - 1 == stored_payload_info_ptr->block_number) {
+            // Check that stored block number matches to given one
+            if (block_number == stored_payload_info_ptr->block_number) {
                 return true;
             }
         }
@@ -1763,11 +1757,11 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             bool blocks_in_order = true;
 
             if (block_number > 0 &&
-                !sn_coap_protocol_linked_list_blockwise_payload_compare_block_number(handle,
+                !sn_coap_protocol_linked_list_blockwise_payload_search_compare_block_number(handle,
                                                                                      src_addr_ptr,
                                                                                      received_coap_msg_ptr->token_ptr,
                                                                                      received_coap_msg_ptr->token_len,
-                                                                                     block_number)) {
+                                                                                     block_number - 1)) {
                 blocks_in_order = false;
             }
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -64,7 +64,7 @@ static void                  sn_coap_protocol_linked_list_blockwise_payload_remo
 static uint32_t              sn_coap_protocol_linked_list_blockwise_payloads_get_len(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint8_t *token_ptr, uint8_t token_len);
 static void                  sn_coap_protocol_handle_blockwise_timout(struct coap_s *handle);
 static sn_coap_hdr_s        *sn_coap_handle_blockwise_message(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *received_coap_msg_ptr, void *param);
-static sn_coap_hdr_s        *sn_coap_protocol_copy_header(struct coap_s *handle, sn_coap_hdr_s *source_header_ptr);
+static sn_coap_hdr_s        *sn_coap_protocol_copy_header(struct coap_s *handle, const sn_coap_hdr_s *source_header_ptr);
 #endif
 
 #if ENABLE_RESENDINGS
@@ -539,7 +539,7 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         }
 
         stored_blockwise_msg_ptr->coap_msg_ptr->payload_len = original_payload_len;
-        stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr = handle->sn_coap_protocol_malloc(stored_blockwise_msg_ptr->coap_msg_ptr->payload_len);
+        stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr = sn_coap_protocol_malloc_copy(handle, src_coap_msg_ptr->payload_ptr, stored_blockwise_msg_ptr->coap_msg_ptr->payload_len);
 
         if (!stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr) {
             //block payload save failed, only first block can be build. Perhaps we should return error.
@@ -548,7 +548,6 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
             tr_error("sn_coap_protocol_build - block payload allocation failed!");
             return byte_count_built;
         }
-        memcpy(stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr, src_coap_msg_ptr->payload_ptr, stored_blockwise_msg_ptr->coap_msg_ptr->payload_len);
 
         stored_blockwise_msg_ptr->coap = handle;
         stored_blockwise_msg_ptr->param = param;
@@ -1309,7 +1308,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
 
 
     /* Allocate memory for stored Payload's data */
-    stored_blockwise_payload_ptr->payload_ptr = handle->sn_coap_protocol_malloc(stored_payload_len);
+    stored_blockwise_payload_ptr->payload_ptr = sn_coap_protocol_malloc_copy(handle, stored_payload_ptr, stored_payload_len);
 
     if (stored_blockwise_payload_ptr->payload_ptr == NULL) {
         tr_error("sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate payload!");
@@ -1318,7 +1317,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
     }
 
     /* Allocate memory for stored Payload's address */
-    stored_blockwise_payload_ptr->addr_ptr = handle->sn_coap_protocol_malloc(addr_ptr->addr_len);
+    stored_blockwise_payload_ptr->addr_ptr = sn_coap_protocol_malloc_copy(handle, addr_ptr->addr_ptr, addr_ptr->addr_len);
 
     if (stored_blockwise_payload_ptr->addr_ptr == NULL) {
         tr_error("sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate address pointer!");
@@ -1350,9 +1349,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
 
     stored_blockwise_payload_ptr->timestamp = handle->system_time;
 
-    memcpy(stored_blockwise_payload_ptr->addr_ptr, addr_ptr->addr_ptr, addr_ptr->addr_len);
     stored_blockwise_payload_ptr->port = addr_ptr->port;
-    memcpy(stored_blockwise_payload_ptr->payload_ptr, stored_payload_ptr, stored_payload_len);
     stored_blockwise_payload_ptr->payload_len = stored_payload_len;
 
     stored_blockwise_payload_ptr->coap = handle;
@@ -1592,14 +1589,11 @@ coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn
 
     msg_ptr->send_msg_ptr.packet_ptr = handle->sn_coap_protocol_malloc(packet_data_len);
 
-    if (msg_ptr->send_msg_ptr.packet_ptr == NULL) {
-        sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
-        return 0;
-    }
-
     msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr = handle->sn_coap_protocol_malloc(dst_addr_ptr->addr_len);
 
-    if (msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr == NULL) {
+    if ((msg_ptr->send_msg_ptr.dst_addr_ptr.addr_ptr == NULL) ||
+        (msg_ptr->send_msg_ptr.packet_ptr == NULL)) {
+
         sn_coap_protocol_release_allocated_send_msg_mem(handle, msg_ptr);
         return 0;
     }
@@ -1939,9 +1933,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 src_coap_blockwise_ack_msg_ptr->msg_id = received_coap_msg_ptr->msg_id;
 
                 // Copy token to response
-                src_coap_blockwise_ack_msg_ptr->token_ptr = handle->sn_coap_protocol_malloc(received_coap_msg_ptr->token_len);
+                src_coap_blockwise_ack_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                 if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
-                    memcpy(src_coap_blockwise_ack_msg_ptr->token_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                     src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
                 }
 
@@ -2267,9 +2260,8 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     src_coap_blockwise_ack_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
                     if (received_coap_msg_ptr->token_len && src_coap_blockwise_ack_msg_ptr->token_ptr) {
                         handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->token_ptr);
-                        src_coap_blockwise_ack_msg_ptr->token_ptr = handle->sn_coap_protocol_malloc(received_coap_msg_ptr->token_len);
+                        src_coap_blockwise_ack_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                         if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
-                            memcpy(src_coap_blockwise_ack_msg_ptr->token_ptr, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
                             src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
                         }
                     }
@@ -2335,7 +2327,7 @@ int8_t sn_coap_convert_block_size(uint16_t block_size)
     return 0;
 }
 
-static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, sn_coap_hdr_s *source_header_ptr)
+static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, const sn_coap_hdr_s *source_header_ptr)
 {
     sn_coap_hdr_s *destination_header_ptr;
 
@@ -2352,24 +2344,22 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, sn_coa
 
     if (source_header_ptr->uri_path_ptr) {
         destination_header_ptr->uri_path_len = source_header_ptr->uri_path_len;
-        destination_header_ptr->uri_path_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->uri_path_len);
+        destination_header_ptr->uri_path_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->uri_path_ptr, source_header_ptr->uri_path_len);
         if (!destination_header_ptr->uri_path_ptr) {
             tr_error("sn_coap_protocol_copy_header - failed to allocate uri path!");
             sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
             return 0;
         }
-        memcpy(destination_header_ptr->uri_path_ptr, source_header_ptr->uri_path_ptr, source_header_ptr->uri_path_len);
     }
 
     if (source_header_ptr->token_ptr) {
         destination_header_ptr->token_len = source_header_ptr->token_len;
-        destination_header_ptr->token_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->token_len);
+        destination_header_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->token_ptr, source_header_ptr->token_len);
         if (!destination_header_ptr->token_ptr) {
             sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
             tr_error("sn_coap_protocol_copy_header - failed to allocate token!");
             return 0;
         }
-        memcpy(destination_header_ptr->token_ptr, source_header_ptr->token_ptr, source_header_ptr->token_len);
     }
 
     destination_header_ptr->content_format = source_header_ptr->content_format;
@@ -2386,59 +2376,54 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, sn_coa
 
         if (source_header_ptr->options_list_ptr->proxy_uri_ptr) {
             destination_header_ptr->options_list_ptr->proxy_uri_len = source_header_ptr->options_list_ptr->proxy_uri_len;
-            destination_header_ptr->options_list_ptr->proxy_uri_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->options_list_ptr->proxy_uri_len);
+            destination_header_ptr->options_list_ptr->proxy_uri_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->proxy_uri_ptr, source_header_ptr->options_list_ptr->proxy_uri_len);
             if (!destination_header_ptr->options_list_ptr->proxy_uri_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate proxy uri!");
                 return 0;
             }
-            memcpy(destination_header_ptr->options_list_ptr->proxy_uri_ptr, source_header_ptr->options_list_ptr->proxy_uri_ptr, source_header_ptr->options_list_ptr->proxy_uri_len);
         }
 
         if (source_header_ptr->options_list_ptr->etag_ptr) {
             destination_header_ptr->options_list_ptr->etag_len = source_header_ptr->options_list_ptr->etag_len;
-            destination_header_ptr->options_list_ptr->etag_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->options_list_ptr->etag_len);
+            destination_header_ptr->options_list_ptr->etag_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->etag_ptr, source_header_ptr->options_list_ptr->etag_len);
             if (!destination_header_ptr->options_list_ptr->etag_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate etag!");
                 return 0;
             }
-            memcpy(destination_header_ptr->options_list_ptr->etag_ptr, source_header_ptr->options_list_ptr->etag_ptr, source_header_ptr->options_list_ptr->etag_len);
         }
 
         if (source_header_ptr->options_list_ptr->uri_host_ptr) {
             destination_header_ptr->options_list_ptr->uri_host_len = source_header_ptr->options_list_ptr->uri_host_len;
-            destination_header_ptr->options_list_ptr->uri_host_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->options_list_ptr->uri_host_len);
+            destination_header_ptr->options_list_ptr->uri_host_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->uri_host_ptr, source_header_ptr->options_list_ptr->uri_host_len);
             if (!destination_header_ptr->options_list_ptr->uri_host_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate uri host!");
                 return 0;
             }
-            memcpy(destination_header_ptr->options_list_ptr->uri_host_ptr, source_header_ptr->options_list_ptr->uri_host_ptr, source_header_ptr->options_list_ptr->uri_host_len);
         }
 
         if (source_header_ptr->options_list_ptr->location_path_ptr) {
             destination_header_ptr->options_list_ptr->location_path_len = source_header_ptr->options_list_ptr->location_path_len;
-            destination_header_ptr->options_list_ptr->location_path_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->options_list_ptr->location_path_len);
+            destination_header_ptr->options_list_ptr->location_path_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->location_path_ptr, source_header_ptr->options_list_ptr->location_path_len);
             if (!destination_header_ptr->options_list_ptr->location_path_ptr) {
                 tr_error("sn_coap_protocol_copy_header - failed to allocate location path!");
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 return 0;
             }
-            memcpy(destination_header_ptr->options_list_ptr->location_path_ptr, source_header_ptr->options_list_ptr->location_path_ptr, source_header_ptr->options_list_ptr->location_path_len);
         }
 
         destination_header_ptr->options_list_ptr->uri_port = source_header_ptr->options_list_ptr->uri_port;
 
         if (source_header_ptr->options_list_ptr->location_query_ptr) {
             destination_header_ptr->options_list_ptr->location_query_len = source_header_ptr->options_list_ptr->location_query_len;
-            destination_header_ptr->options_list_ptr->location_query_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->options_list_ptr->location_query_len);
+            destination_header_ptr->options_list_ptr->location_query_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->location_query_ptr, source_header_ptr->options_list_ptr->location_query_len);
             if (!destination_header_ptr->options_list_ptr->location_query_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate location query!");
                 return 0;
             }
-            memcpy(destination_header_ptr->options_list_ptr->location_query_ptr, source_header_ptr->options_list_ptr->location_query_ptr, source_header_ptr->options_list_ptr->location_query_len);
         }
 
         destination_header_ptr->options_list_ptr->observe = source_header_ptr->options_list_ptr->observe;
@@ -2446,13 +2431,12 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, sn_coa
 
         if (source_header_ptr->options_list_ptr->uri_query_ptr) {
             destination_header_ptr->options_list_ptr->uri_query_len = source_header_ptr->options_list_ptr->uri_query_len;
-            destination_header_ptr->options_list_ptr->uri_query_ptr = handle->sn_coap_protocol_malloc(source_header_ptr->options_list_ptr->uri_query_len);
+            destination_header_ptr->options_list_ptr->uri_query_ptr = sn_coap_protocol_malloc_copy(handle, source_header_ptr->options_list_ptr->uri_query_ptr, source_header_ptr->options_list_ptr->uri_query_len);
             if (!destination_header_ptr->options_list_ptr->uri_query_ptr) {
                 sn_coap_parser_release_allocated_coap_msg_mem(handle, destination_header_ptr);
                 tr_error("sn_coap_protocol_copy_header - failed to allocate uri query!");
                 return 0;
             }
-            memcpy(destination_header_ptr->options_list_ptr->uri_query_ptr, source_header_ptr->options_list_ptr->uri_query_ptr, source_header_ptr->options_list_ptr->uri_query_len);
         }
 
         destination_header_ptr->options_list_ptr->block1 = source_header_ptr->options_list_ptr->block1;
@@ -2491,3 +2475,28 @@ static bool sn_coap_protocol_update_duplicate_package_data(const struct coap_s *
     return true;
 }
 #endif
+
+void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint16_t length)
+{
+    void *dest = handle->sn_coap_protocol_malloc(length);
+
+    if ((dest) && (source)) {
+        memcpy(dest, source, length);
+    }
+    return dest;
+}
+
+/*
+ * This should logically be part and accessed via of the coap_s just as malloc() & free()
+ * are, but that would require the client to fill one up, as a wrapper filled from this
+ * class would need access to the handle itself.
+ */
+void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length)
+{
+    void *result = handle->sn_coap_protocol_malloc(length);
+
+    if (result) {
+        memset(result, 0, length);
+    }
+    return result;
+}

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -1756,7 +1756,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             }
 
             // Check that incoming block number is in order.
-            uint32_t block_number = received_coap_msg_ptr->options_list_ptr->block1 >> 4;
+            const uint32_t block_number = received_coap_msg_ptr->options_list_ptr->block1 >> 4;
             bool blocks_in_order = true;
 
             if (block_number > 0 &&
@@ -1780,15 +1780,9 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             /* Block option length can be 1-3 bytes. First 4-20 bits are for block number. Last 4 bits are ALWAYS more bit + block size. */
             if (received_coap_msg_ptr->options_list_ptr->block1 & 0x08) {
 
-                src_coap_blockwise_ack_msg_ptr = sn_coap_parser_alloc_message(handle);
+                src_coap_blockwise_ack_msg_ptr = sn_coap_parser_alloc_message_with_options(handle);
                 if (src_coap_blockwise_ack_msg_ptr == NULL) {
                     tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate ack message!");
-                    return NULL;
-                }
-
-                if (sn_coap_parser_alloc_options(handle, src_coap_blockwise_ack_msg_ptr) == NULL) {
-                   tr_error("sn_coap_handle_blockwise_message - (recv block1) failed to allocate options!");
-                    handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
                     return NULL;
                 }
 
@@ -1936,18 +1930,10 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         return 0;
                     }
 
-                    src_coap_blockwise_ack_msg_ptr = sn_coap_parser_alloc_message(handle);
+                    /* * * Then build CoAP Acknowledgement message * * */
+                    src_coap_blockwise_ack_msg_ptr = sn_coap_parser_alloc_message_with_options(handle);
                     if (src_coap_blockwise_ack_msg_ptr == NULL) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate message!");
-                        return 0;
-                    }
-
-                    /* * * Then build CoAP Acknowledgement message * * */
-
-                    if (sn_coap_parser_alloc_options(handle, src_coap_blockwise_ack_msg_ptr) == NULL) {
-                        tr_error("sn_coap_handle_blockwise_message - (send block2) failed to allocate options!");
-                        handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr);
-                        src_coap_blockwise_ack_msg_ptr = 0;
                         return NULL;
                     }
 
@@ -1990,7 +1976,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     previous_blockwise_msg_ptr = 0;
 
                     /* Then get needed memory count for Packet data */
-                    dst_packed_data_needed_mem = sn_coap_builder_calc_needed_packet_data_size_2(src_coap_blockwise_ack_msg_ptr ,handle->sn_coap_block_data_size);
+                    dst_packed_data_needed_mem = sn_coap_builder_calc_needed_packet_data_size_2(src_coap_blockwise_ack_msg_ptr, handle->sn_coap_block_data_size);
 
                     /* Then allocate memory for Packet data */
                     dst_ack_packet_data_ptr = sn_coap_protocol_calloc(handle, dst_packed_data_needed_mem);
@@ -2084,13 +2070,14 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
             //NOTE: Getting the first from list might not be correct one
             coap_blockwise_msg_s *stored_blockwise_msg_temp_ptr = sn_coap_stored_blockwise_msg_get(handle, received_coap_msg_ptr);
             if (stored_blockwise_msg_temp_ptr) {
-                uint16_t block_size;
-                uint32_t block_number;
+
+                block_temp = received_coap_msg_ptr->options_list_ptr->block2 & 0x07;
 
                 /* Resolve block parameters */
-                block_number = received_coap_msg_ptr->options_list_ptr->block2 >> 4;
-                block_temp = received_coap_msg_ptr->options_list_ptr->block2 & 0x07;
-                block_size = 1u << (block_temp + 4);
+                const uint16_t block_size = 1u << (block_temp + 4);
+                const uint32_t block_number = received_coap_msg_ptr->options_list_ptr->block2 >> 4;
+
+
                 /* Build response message */
                 src_coap_blockwise_ack_msg_ptr = stored_blockwise_msg_temp_ptr->coap_msg_ptr;
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -51,6 +51,7 @@
 static void                  sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id, void *param);
 static coap_duplication_info_s *sn_coap_protocol_linked_list_duplication_info_search(const struct coap_s *handle, const sn_nsdl_addr_s *scr_addr_ptr, const uint16_t msg_id);
 static void                  sn_coap_protocol_linked_list_duplication_info_remove_old_ones(struct coap_s *handle);
+static void                  sn_coap_protocol_duplication_info_free(struct coap_s *handle, coap_duplication_info_s *duplication_info_ptr);
 static bool                  sn_coap_protocol_update_duplicate_package_data(const struct coap_s *handle, const sn_nsdl_addr_s *dst_addr_ptr, const sn_coap_hdr_s *coap_msg_ptr, const int16_t data_size, const uint8_t *dst_packet_data_ptr);
 #endif
 
@@ -76,6 +77,8 @@ static void                  sn_coap_protocol_release_allocated_send_msg_mem(str
 static uint16_t              sn_coap_count_linked_list_size(const coap_send_msg_list_t *linked_list_ptr);
 static uint32_t              sn_coap_calculate_new_resend_time(const uint32_t current_time, const uint8_t interval, const uint8_t counter);
 #endif
+
+static uint16_t              get_new_message_id(void);
 
 static bool                  compare_address_and_port(const sn_nsdl_addr_s* left, const sn_nsdl_addr_s* right);
 
@@ -362,7 +365,7 @@ int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint16_t ms
     return -2;
 }
 
-int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, uint8_t *token, uint8_t token_len)
+int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, const uint8_t *token, uint8_t token_len)
 {
 #if ENABLE_RESENDINGS /* If Message resending is not used at all, this part of code will not be compiled */
     if (handle == NULL || token == NULL || token_len == 0) {
@@ -373,9 +376,7 @@ int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, ui
     ns_list_foreach(coap_send_msg_s, stored_msg, &handle->linked_list_resent_msgs) {
         uint8_t stored_token_len =  (stored_msg->send_msg_ptr.packet_ptr[0] & 0x0F);
         if (stored_token_len == token_len) {
-            uint8_t stored_token[8];
-            memcpy(stored_token, &stored_msg->send_msg_ptr.packet_ptr[4], stored_token_len);
-            if (memcmp(stored_token, token, stored_token_len) == 0) {
+            if (memcmp(&stored_msg->send_msg_ptr.packet_ptr[4], token, stored_token_len) == 0) {
                 uint16_t temp_msg_id = (stored_msg->send_msg_ptr.packet_ptr[2] << 8);
                 temp_msg_id += (uint16_t)stored_msg->send_msg_ptr.packet_ptr[3];
                 tr_debug("sn_coap_protocol_delete_retransmission_by_token - removed msg_id: %d", temp_msg_id);
@@ -457,12 +458,9 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
     if (src_coap_msg_ptr->msg_type != COAP_MSG_TYPE_ACKNOWLEDGEMENT &&
             src_coap_msg_ptr->msg_type != COAP_MSG_TYPE_RESET &&
             src_coap_msg_ptr->msg_id == 0) {
-        /* * * * Generate new Message ID and increase it by one  * * * */
-        src_coap_msg_ptr->msg_id = message_id;
-        message_id++;
-        if (message_id == 0) {
-            message_id = 1;
-        }
+
+        /* * * * Generate new Message ID * * * */
+        src_coap_msg_ptr->msg_id = get_new_message_id();
     }
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
@@ -512,6 +510,8 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
 #endif
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
+
+    // XXX: combine these two
 
     /* If blockwising needed */
     if ((original_payload_len > handle->sn_coap_block_data_size) && (handle->sn_coap_block_data_size > 0)) {
@@ -618,9 +618,11 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
     /* * * * Check validity of parsed Header values  * * * */
     if (sn_coap_header_validity_check(returned_dst_coap_msg_ptr, coap_version) != 0) {
         /* If message code is in a reserved class (1, 6 or 7), send reset. Message code class is 3 MSB of the message code byte     */
-        if (((returned_dst_coap_msg_ptr->msg_code >> 5) == 1) ||        // if class == 1
-                ((returned_dst_coap_msg_ptr->msg_code >> 5) == 6) ||    // if class == 6
-                ((returned_dst_coap_msg_ptr->msg_code >> 5) == 7)) {    // if class == 7
+
+        const uint8_t msg_code_class = returned_dst_coap_msg_ptr->msg_code >> 5;
+        if ((msg_code_class == 1) ||        // if class == 1
+                (msg_code_class == 6) ||    // if class == 6
+                (msg_code_class == 7)) {    // if class == 7
             tr_error("sn_coap_protocol_parse - message code not valid!");
             sn_coap_protocol_send_rst(handle, returned_dst_coap_msg_ptr->msg_id, src_addr_ptr, param);
         }
@@ -1089,7 +1091,7 @@ static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *h
     stored_duplication_info_ptr->address = sn_coap_protocol_calloc(handle, sizeof(sn_nsdl_addr_s));
     if (stored_duplication_info_ptr->address == NULL) {
         tr_error("sn_coap_protocol_linked_list_duplication_info_store - failed to allocate address!");
-        handle->sn_coap_protocol_free(stored_duplication_info_ptr);
+        sn_coap_protocol_duplication_info_free(handle, stored_duplication_info_ptr);
         return;
     }
 
@@ -1097,8 +1099,7 @@ static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *h
 
     if (stored_duplication_info_ptr->address->addr_ptr == NULL) {
         tr_error("sn_coap_protocol_linked_list_duplication_info_store - failed to allocate address pointer!");
-        handle->sn_coap_protocol_free(stored_duplication_info_ptr->address);
-        handle->sn_coap_protocol_free(stored_duplication_info_ptr);
+        sn_coap_protocol_duplication_info_free(handle, stored_duplication_info_ptr);
         return;
     }
 
@@ -1167,10 +1168,7 @@ static void sn_coap_protocol_linked_list_duplication_info_remove_old_ones(struct
             --handle->count_duplication_msgs;
 
             /* Free memory of stored Duplication info */
-            handle->sn_coap_protocol_free(removed_duplication_info_ptr->address->addr_ptr);
-            handle->sn_coap_protocol_free(removed_duplication_info_ptr->address);
-            handle->sn_coap_protocol_free(removed_duplication_info_ptr->packet_ptr);
-            handle->sn_coap_protocol_free(removed_duplication_info_ptr);
+            sn_coap_protocol_duplication_info_free(handle, removed_duplication_info_ptr);
         }
     }
 }
@@ -1196,10 +1194,7 @@ void sn_coap_protocol_linked_list_duplication_info_remove(struct coap_s *handle,
                     --handle->count_duplication_msgs;
 
                     /* Free memory of stored Duplication info */
-                    handle->sn_coap_protocol_free(removed_duplication_info_ptr->address->addr_ptr);
-                    handle->sn_coap_protocol_free(removed_duplication_info_ptr->address);
-                    handle->sn_coap_protocol_free(removed_duplication_info_ptr->packet_ptr);
-                    handle->sn_coap_protocol_free(removed_duplication_info_ptr);
+                    sn_coap_protocol_duplication_info_free(handle, removed_duplication_info_ptr);
                     return;
                 }
             }
@@ -1212,6 +1207,18 @@ void sn_coap_protocol_linked_list_duplication_info_remove(struct coap_s *handle,
     (void)msg_id;
 #endif //SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 }
+static void sn_coap_protocol_duplication_info_free(struct coap_s *handle, coap_duplication_info_s *duplication_info_ptr)
+{
+    if (duplication_info_ptr) {
+        if (duplication_info_ptr->address) {
+            handle->sn_coap_protocol_free(duplication_info_ptr->address->addr_ptr);
+            handle->sn_coap_protocol_free(duplication_info_ptr->address);
+        }
+        handle->sn_coap_protocol_free(duplication_info_ptr->packet_ptr);
+        handle->sn_coap_protocol_free(duplication_info_ptr);
+    }
+}
+
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 /**************************************************************************//**
@@ -1228,10 +1235,8 @@ static void sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *han
         ns_list_remove(&handle->linked_list_blockwise_sent_msgs, removed_msg_ptr);
 
         if( removed_msg_ptr->coap_msg_ptr ){
-            if (removed_msg_ptr->coap_msg_ptr->payload_ptr) {
-                handle->sn_coap_protocol_free(removed_msg_ptr->coap_msg_ptr->payload_ptr);
-                removed_msg_ptr->coap_msg_ptr->payload_ptr = 0;
-            }
+            handle->sn_coap_protocol_free(removed_msg_ptr->coap_msg_ptr->payload_ptr);
+            removed_msg_ptr->coap_msg_ptr->payload_ptr = 0;
 
             sn_coap_parser_release_allocated_coap_msg_mem(handle, removed_msg_ptr->coap_msg_ptr);
         }
@@ -1449,10 +1454,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_remove(struct coap_s 
     /* Free memory of stored payload */
     handle->sn_coap_protocol_free(removed_payload_ptr->addr_ptr);
     handle->sn_coap_protocol_free(removed_payload_ptr->payload_ptr);
-    if (removed_payload_ptr->token_ptr != NULL) {
-        handle->sn_coap_protocol_free(removed_payload_ptr->token_ptr);
-        removed_payload_ptr->token_ptr = 0;
-    }
+    handle->sn_coap_protocol_free(removed_payload_ptr->token_ptr);
 
     handle->sn_coap_protocol_free(removed_payload_ptr);
 }
@@ -1787,10 +1789,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
                     }
-                    src_coap_blockwise_ack_msg_ptr->msg_id = message_id++;
-                    if (message_id == 0) {
-                        message_id = 1;
-                    }
+                    src_coap_blockwise_ack_msg_ptr->msg_id = get_new_message_id();
 
                     sn_coap_builder_2(dst_ack_packet_data_ptr, src_coap_blockwise_ack_msg_ptr, handle->sn_coap_block_data_size);
 
@@ -2038,10 +2037,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         return NULL;
                     }
 
-                    src_coap_blockwise_ack_msg_ptr->msg_id = message_id++;
-                    if (message_id == 0) {
-                        message_id = 1;
-                    }
+                    src_coap_blockwise_ack_msg_ptr->msg_id = get_new_message_id();
 
                     /* Update block option */
                     block_temp = received_coap_msg_ptr->options_list_ptr->block2 & 0x07;
@@ -2055,34 +2051,33 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     /* Set BLOCK2 (subsequent) GET msg code and copy uri path from previous msg*/
                     src_coap_blockwise_ack_msg_ptr->msg_code = previous_blockwise_msg_ptr->coap_msg_ptr->msg_code;
                     if (previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_ptr) {
-                        src_coap_blockwise_ack_msg_ptr->uri_path_len = previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len;
-                        src_coap_blockwise_ack_msg_ptr->uri_path_ptr = handle->sn_coap_protocol_malloc(previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len);
+                        src_coap_blockwise_ack_msg_ptr->uri_path_ptr = sn_coap_protocol_malloc_copy(handle, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len);
+
                         if (!src_coap_blockwise_ack_msg_ptr->uri_path_ptr) {
                             sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                             tr_error("sn_coap_handle_blockwise_message - failed to allocate for uri path ptr!");
                             return NULL;
                         }
-                        memcpy(src_coap_blockwise_ack_msg_ptr->uri_path_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len);
+                        src_coap_blockwise_ack_msg_ptr->uri_path_len = previous_blockwise_msg_ptr->coap_msg_ptr->uri_path_len;
                     }
                     if (previous_blockwise_msg_ptr->coap_msg_ptr->token_ptr) {
-                        src_coap_blockwise_ack_msg_ptr->token_len = previous_blockwise_msg_ptr->coap_msg_ptr->token_len;
-                        src_coap_blockwise_ack_msg_ptr->token_ptr = handle->sn_coap_protocol_malloc(previous_blockwise_msg_ptr->coap_msg_ptr->token_len);
+
+                        src_coap_blockwise_ack_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, previous_blockwise_msg_ptr->coap_msg_ptr->token_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->token_len);
                         if (!src_coap_blockwise_ack_msg_ptr->token_ptr) {
                             sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                             tr_error("sn_coap_handle_blockwise_message - failed to allocate for token ptr!");
                             return NULL;
                         }
-                        memcpy(src_coap_blockwise_ack_msg_ptr->token_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->token_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->token_len);
+                        src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
                     }
 
                     ns_list_remove(&handle->linked_list_blockwise_sent_msgs, previous_blockwise_msg_ptr);
                     if (previous_blockwise_msg_ptr->coap_msg_ptr) {
-                        if (previous_blockwise_msg_ptr->coap_msg_ptr->payload_ptr) {
-                            handle->sn_coap_protocol_free(previous_blockwise_msg_ptr->coap_msg_ptr->payload_ptr);
-                            previous_blockwise_msg_ptr->coap_msg_ptr->payload_ptr = 0;
-                        }
+
+                        handle->sn_coap_protocol_free(previous_blockwise_msg_ptr->coap_msg_ptr->payload_ptr);
+                        previous_blockwise_msg_ptr->coap_msg_ptr->payload_ptr = 0;
+
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, previous_blockwise_msg_ptr->coap_msg_ptr);
-                        previous_blockwise_msg_ptr->coap_msg_ptr = 0;
                     }
                     handle->sn_coap_protocol_free(previous_blockwise_msg_ptr);
                     previous_blockwise_msg_ptr = 0;
@@ -2104,7 +2099,6 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     if ((sn_coap_builder_2(dst_ack_packet_data_ptr, src_coap_blockwise_ack_msg_ptr, handle->sn_coap_block_data_size)) < 0) {
                         tr_error("sn_coap_handle_blockwise_message - (send block2) builder failed!");
                         handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
-                        dst_ack_packet_data_ptr = 0;
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
                         sn_coap_parser_release_allocated_coap_msg_mem(handle, received_coap_msg_ptr);
                         return NULL;
@@ -2493,4 +2487,13 @@ static bool compare_address_and_port(const sn_nsdl_addr_s* left, const sn_nsdl_a
     }
 
     return match;
+}
+
+static uint16_t get_new_message_id(void)
+{
+    message_id++;
+    if (message_id == 0) {
+        message_id = 1;
+    }
+    return message_id;
 }

--- a/test/mbed-coap/unittest/sn_coap_builder/Makefile
+++ b/test/mbed-coap/unittest/sn_coap_builder/Makefile
@@ -9,6 +9,7 @@ TEST_SRC_FILES = \
         libCoap_builder_test.cpp \
         ../stubs/sn_coap_header_check_stub.c \
         ../stubs/sn_coap_parser_stub.c \
+        ../stubs/sn_coap_protocol_stub.c \
 
 include ../MakefileWorker.mk
 

--- a/test/mbed-coap/unittest/sn_coap_parser/Makefile
+++ b/test/mbed-coap/unittest/sn_coap_parser/Makefile
@@ -10,5 +10,6 @@ TEST_SRC_FILES = \
         main.cpp \
         sn_coap_parsertest.cpp \
         test_sn_coap_parser.c \
+        ../stubs/sn_coap_protocol_stub.c \
 
 include ../MakefileWorker.mk

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -81,8 +81,6 @@ TEST(libCoap_protocol, sn_coap_protocol_destroy)
     ns_list_init(&handle->linked_list_resent_msgs);
     coap_send_msg_s *msg_ptr = (coap_send_msg_s*)malloc(sizeof(coap_send_msg_s));
     memset(msg_ptr, 0, sizeof(coap_send_msg_s));
-    msg_ptr->send_msg_ptr = (sn_nsdl_transmit_s*)malloc(sizeof(sn_nsdl_transmit_s));
-    memset(msg_ptr->send_msg_ptr, 0 , sizeof(sn_nsdl_transmit_s));
 
     ns_list_add_to_end(&handle->linked_list_resent_msgs, msg_ptr);
 #if SN_COAP_DUPLICATION_MAX_MSGS_COUNT
@@ -429,7 +427,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr.options_list_ptr = NULL;
 
     //Test sn_coap_protocol_copy_header here -->
-    retCounter = 6;
+    retCounter = 5;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
     CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
@@ -507,7 +505,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     retCounter = 1;
     handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
-    retCounter = 6;
+    retCounter = 5;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
     CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -469,20 +469,20 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     int buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
     hdr2->payload_ptr = (uint8_t*)malloc(buff_len);
 
-    for( int i=0; i < 8; i++ ){
-        retCounter = 1 + i;
+    for( int i=1; i <= 11; i++ ){
+        retCounter = i;
         sn_coap_builder_stub.expectedInt16 = 1;
         hdr2->payload_len = buff_len;
         int8_t rett = sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL);
         CHECK( -2 == rett );
     }
 
-    retCounter = 11;
+    retCounter = 12;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr2->payload_len = buff_len;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));
 
-    retCounter = 11;
+    retCounter = 12;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr2->payload_len = buff_len;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -268,7 +268,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     memset(addr.addr_ptr, '1', 5);
 
     sn_coap_builder_stub.expectedInt16 = 0;
-    retCounter = 2;
+    retCounter = 6;
 
     CHECK( 0 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
@@ -362,25 +362,25 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     sn_coap_builder_stub.expectedInt16 = -1;
     CHECK( -1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
-    retCounter = 2;
+    retCounter = 6;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
     hdr.msg_code = COAP_MSG_CODE_EMPTY;
 
-    retCounter = 2;
+    retCounter = 7;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
-    retCounter = 4;
+    retCounter = 8;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
-    retCounter = 4;
+    retCounter = 9;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
-    retCounter = 5;
+    retCounter = 10;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
@@ -390,7 +390,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
 
     sn_coap_protocol_clear_retransmission_buffer(handle);
-    retCounter = 2;
+    retCounter = 7;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
     free(hdr.payload_ptr);
@@ -399,7 +399,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     memset(hdr.payload_ptr, '1', SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20);
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
 
-    retCounter = 4;
+    retCounter = 8;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
@@ -408,7 +408,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     memset(hdr.payload_ptr, '1', UINT16_MAX);
     hdr.payload_len = UINT16_MAX;
 
-    retCounter = 4;
+    retCounter = 9;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
@@ -417,7 +417,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     memset(hdr.payload_ptr, '1', UINT16_MAX - 1);
     hdr.payload_len = UINT16_MAX - 1;
 
-    retCounter = 4;
+    retCounter = 10;
     sn_coap_builder_stub.expectedInt16 = 1;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
@@ -429,7 +429,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr.options_list_ptr = NULL;
 
     //Test sn_coap_protocol_copy_header here -->
-    retCounter = 3;
+    retCounter = 6;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
     CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
@@ -497,7 +497,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     //<-- Test sn_coap_protocol_copy_header here
 
     hdr.msg_code = COAP_MSG_CODE_REQUEST_GET;
-    retCounter = 4;
+    retCounter = 7;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
@@ -507,12 +507,12 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     retCounter = 1;
     handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
-    retCounter = 3;
+    retCounter = 6;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
     CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
 
-    retCounter = 4;
+    retCounter = 8;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -208,7 +208,7 @@ TEST(libCoap_protocol, sn_coap_protocol_delete_retransmission_by_token)
     sn_nsdl_addr_s dst_addr_ptr;
     sn_coap_hdr_s src_coap_msg_ptr;
     uint8_t temp_addr[4] = {0};
-    uint8_t dst_packet_data_ptr[5] = {0x04, 0x00, 0x00, 0x63, 0x10};
+    uint8_t dst_packet_data_ptr[9] = {0x04, 0x00, 0x00, 0x63, 0x10, 0x10, 0x10, 0x10};
 
     memset(&dst_addr_ptr, 0, sizeof(sn_nsdl_addr_s));
     memset(&src_coap_msg_ptr, 0, sizeof(sn_coap_hdr_s));
@@ -216,8 +216,8 @@ TEST(libCoap_protocol, sn_coap_protocol_delete_retransmission_by_token)
     dst_addr_ptr.addr_ptr = temp_addr;
     dst_addr_ptr.addr_len = 4;
     dst_addr_ptr.type = SN_NSDL_ADDRESS_TYPE_IPV4;
-    src_coap_msg_ptr.token_ptr = (uint8_t*)malloc(1);
-    memset(src_coap_msg_ptr.token_ptr, 0x10, 1);
+    src_coap_msg_ptr.token_ptr = (uint8_t*)malloc(4);
+    memset(src_coap_msg_ptr.token_ptr, 0x10, 4);
     src_coap_msg_ptr.token_len = 4;
 
     struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
@@ -228,7 +228,7 @@ TEST(libCoap_protocol, sn_coap_protocol_delete_retransmission_by_token)
                                                                  src_coap_msg_ptr.token_ptr,
                                                                  src_coap_msg_ptr.token_len));
 
-    sn_coap_builder_stub.expectedInt16 = 5;
+    sn_coap_builder_stub.expectedInt16 = 9;
 
     CHECK( 0 < sn_coap_protocol_build(handle, &dst_addr_ptr, dst_packet_data_ptr, &src_coap_msg_ptr, NULL));
 
@@ -916,8 +916,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    free(list);
-    free(sn_coap_parser_stub.expectedHeader);
+
     sn_coap_protocol_set_block_size(handle, SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE);
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -1708,7 +1707,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     //<-- block2 length == 1,2,3
 
@@ -1783,8 +1781,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    free(list);
-    free(sn_coap_parser_stub.expectedHeader);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -1831,8 +1827,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    free(list);
-    free(sn_coap_parser_stub.expectedHeader);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -2243,7 +2237,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
+
     sn_coap_protocol_destroy(handle);
 
     // sn_coap_handle_blockwise_message - failed to allocate for token ptr!
@@ -2303,7 +2297,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
+
     sn_coap_protocol_destroy(handle);
 
     // sn_coap_handle_blockwise_message - (send block2) failed to allocate packet!
@@ -2519,7 +2513,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -2541,7 +2534,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -2563,7 +2555,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -2585,7 +2576,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -2607,7 +2597,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL == ret );
     free(payload);
-    sn_coap_parser_release_allocated_coap_msg_mem(handle, sn_coap_parser_stub.expectedHeader);
 
     sn_coap_parser_stub.expectedHeader = (sn_coap_hdr_s *)malloc(sizeof(sn_coap_hdr_s));
     memset(sn_coap_parser_stub.expectedHeader, 0, sizeof(sn_coap_hdr_s));
@@ -2943,7 +2932,7 @@ TEST(libCoap_protocol, sn_coap_protocol_block_remove)
     sn_coap_builder_stub.expectedUint16 = 1;
 
     // Success
-    retCounter = 10;
+    retCounter = 19;
     sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 1);
     sn_coap_protocol_block_remove(handle,addr,packet_data_len,packet_data_ptr);

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -427,7 +427,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr.options_list_ptr = NULL;
 
     //Test sn_coap_protocol_copy_header here -->
-    retCounter = 5;
+    retCounter = 4;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
     CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));
@@ -505,7 +505,7 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     retCounter = 1;
     handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
 
-    retCounter = 5;
+    retCounter = 4;
     sn_coap_builder_stub.expectedInt16 = 1;
     hdr.payload_len = 0;
     CHECK( -2 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, &hdr, NULL));

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -125,7 +125,6 @@ TEST(libCoap_protocol, sn_coap_protocol_clear_sent_blockwise_messages)
 
     coap_blockwise_msg_s *message = (coap_blockwise_msg_s*)malloc(sizeof(coap_blockwise_msg_s));
     memset(message, 0, sizeof(coap_blockwise_msg_s));
-    message->coap = coap_handle;
     message->coap_msg_ptr = (sn_coap_hdr_s*)malloc(sizeof(sn_coap_hdr_s));
     memset(message->coap_msg_ptr, 0, sizeof(sn_coap_hdr_s));
     message->coap_msg_ptr->payload_ptr = (uint8_t*)malloc(5);
@@ -2992,7 +2991,6 @@ TEST(libCoap_protocol, sn_coap_protocol_remove_sent_blockwise_message)
     struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
     coap_blockwise_msg_s *message = (coap_blockwise_msg_s *)malloc(sizeof(coap_blockwise_msg_s));
     memset(message, 0, sizeof(coap_blockwise_msg_s));
-    message->coap = handle;
     message->coap_msg_ptr = (sn_coap_hdr_s*)malloc(sizeof(sn_coap_hdr_s));
     memset(message->coap_msg_ptr, 0, sizeof(sn_coap_hdr_s));
     message->coap_msg_ptr->msg_id = 100;

--- a/test/mbed-coap/unittest/stubs/sn_coap_builder_stub.c
+++ b/test/mbed-coap/unittest/stubs/sn_coap_builder_stub.c
@@ -34,27 +34,27 @@
 
 sn_coap_builder_stub_def sn_coap_builder_stub;
 
-sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
+sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, const sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
 {
     return sn_coap_builder_stub.expectedHeader;
 }
 
-int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_size)
+int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_size)
 {
     return sn_coap_builder_stub.expectedInt16;
 }
 
-int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr)
+int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     return sn_coap_builder_stub.expectedInt16;
 }
 
-uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_size)
+uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_size)
 {
     return sn_coap_builder_stub.expectedUint16;
 }
 
-uint16_t sn_coap_builder_calc_needed_packet_data_size(sn_coap_hdr_s *src_coap_msg_ptr)
+uint16_t sn_coap_builder_calc_needed_packet_data_size(const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     return sn_coap_builder_stub.expectedUint16;
 }

--- a/test/mbed-coap/unittest/stubs/sn_coap_parser_stub.c
+++ b/test/mbed-coap/unittest/stubs/sn_coap_parser_stub.c
@@ -93,6 +93,29 @@ sn_coap_hdr_s *sn_coap_parser_init_message(sn_coap_hdr_s *coap_msg_ptr)
     return coap_msg_ptr;
 }
 
+sn_coap_hdr_s *sn_coap_parser_alloc_message_with_options(struct coap_s *handle)
+{
+    // check the handle just as in any other place
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    sn_coap_hdr_s *coap_msg_ptr = sn_coap_parser_alloc_message(handle);
+
+    sn_coap_options_list_s *options_list_ptr = sn_coap_parser_alloc_options(handle, coap_msg_ptr);
+
+    if ((coap_msg_ptr == NULL) || (options_list_ptr == NULL)) {
+
+        // oops, out of memory free if got already any
+        free(coap_msg_ptr);
+        free(options_list_ptr);
+
+        coap_msg_ptr = NULL;
+    }
+
+    return coap_msg_ptr;
+}
+
 sn_coap_hdr_s *sn_coap_parser_alloc_message(struct coap_s *handle)
 {
     sn_coap_hdr_s *returned_coap_msg_ptr;

--- a/test/mbed-coap/unittest/stubs/sn_coap_protocol_stub.c
+++ b/test/mbed-coap/unittest/stubs/sn_coap_protocol_stub.c
@@ -112,4 +112,28 @@ void sn_coap_protocol_block_remove(struct coap_s *handle, sn_nsdl_addr_s *source
 {
 }
 
+void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint16_t length)
+{
+    void *dest = handle->sn_coap_protocol_malloc(length);
+
+    if ((dest) && (source)) {
+        memcpy(dest, source, length);
+    }
+    return dest;
+}
+
+/*
+ * This should logically be part and accessed via of the coap_s just as malloc() & free()
+ * are, but that would require the client to fill one up, as a wrapper filled from this
+ * class would need access to the handle itself.
+ */
+void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length)
+{
+    void *result = handle->sn_coap_protocol_malloc(length);
+
+    if (result) {
+        memset(result, 0, length);
+    }
+    return result;
+}
 


### PR DESCRIPTION
This is a further improved and rebased version of https://github.com/ARMmbed/mbed-coap/pull/34 and https://github.com/ARMmbed/mbed-coap/pull/83. Aim is to reduce flash usage, but while doing that, the dynamic usage is a also now a bit smaller due to combined structures. 

There are no known build or functional breakages with the users (MCC & Thread stack), this passed also the Thread test CI a few weeks ago.

Flash savings with default configuration on MCC example.

ARMC5:
```
| mbed-coap/source/sn_coap_builder.o      |    1986(-168) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_header_check.o |       142(+0) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_parser.o       |     1678(-32) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_protocol.o     |    5106(-872) |    2(+0) |     0(+0) |
```
-1072 bytes


GCC 6.3:
```
| mbed-coap/source/sn_coap_builder.o      |    2074(-114) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_header_check.o |        84(+0) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_parser.o       |     1664(-32) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_protocol.o     |    5314(-962) |    0(+0) |     2(+0) |
```
-1108 bytes

Further savings are possible on MCC by disabling unused code by setting ```SN_COAP_BLOCKWISE_INTERNAL_BLOCK_2_HANDLING_ENABLED=0```

ARMC5:
```
| mbed-coap/source/sn_coap_builder.o      |     1986(+0) |    0(+0) |      0(+0) |
| mbed-coap/source/sn_coap_header_check.o |      142(+0) |    0(+0) |      0(+0) |
| mbed-coap/source/sn_coap_parser.o       |     1678(+0) |    0(+0) |      0(+0) |
| mbed-coap/source/sn_coap_protocol.o     |   4798(-308) |    2(+0) |      0(+0) |
```
-308 bytes

GCC 6.3:
```
| mbed-coap/source/sn_coap_builder.o      |     2074(+0) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_header_check.o |       84(+0) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_parser.o       |     1664(+0) |    0(+0) |     0(+0) |
| mbed-coap/source/sn_coap_protocol.o     |   4950(-364) |    0(+0) |     2(+0) |
```
-364 bytes