### PR TITLE
Store also ACK's into duplicate message list

### DIFF
--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -666,7 +666,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 0x10;
-    sn_coap_parser_stub.expectedHeader->msg_id = 5;
+    sn_coap_parser_stub.expectedHeader->msg_id = 6;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
     sn_coap_parser_stub.expectedHeader->token_len = sizeof(uint32_t);


### PR DESCRIPTION
It's possible to receive same ACK multiple times and it needs to placed into duplicate list.
EMPTY ACK's are skipped since those are used in separate response case where EMPTY ACK and final response have the same MSG ID.
Fixes error: IOTCLT-3592 - Client does not handle Duplicate ACK messages during blockwise registration correctly