### PR TITLE
Fix duplicate handling block2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v5.1.5](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.5)
+
+- Added handling for duplicate message handling for Block2 messages. Previously CoAP was silently ignoring the duplicate messages. Now proper response will be sent.
+- Added extended version of `sn_coap_protocol_update_duplicate_package_data`, `sn_coap_protocol_update_duplicate_package_data_all` which will handle all CoAP data in the list.
+
 ## [v5.1.4](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.4)
 
 - Add also 4.13 (Request Entity Too Large) responses to duplicate info list.

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -53,6 +53,8 @@ static coap_duplication_info_s *sn_coap_protocol_linked_list_duplication_info_se
 static void                  sn_coap_protocol_linked_list_duplication_info_remove_old_ones(struct coap_s *handle);
 static void                  sn_coap_protocol_duplication_info_free(struct coap_s *handle, coap_duplication_info_s *duplication_info_ptr);
 static bool                  sn_coap_protocol_update_duplicate_package_data(const struct coap_s *handle, const sn_nsdl_addr_s *dst_addr_ptr, const sn_coap_hdr_s *coap_msg_ptr, const int16_t data_size, const uint8_t *dst_packet_data_ptr);
+static bool                  sn_coap_protocol_update_duplicate_package_data_all(const struct coap_s *handle, const sn_nsdl_addr_s *dst_addr_ptr, const sn_coap_hdr_s *coap_msg_ptr, const int16_t data_size, const uint8_t *dst_packet_data_ptr);
+
 #endif
 
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
@@ -690,6 +692,8 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
                     tr_debug("sn_coap_protocol_parse - send ack for duplicate message");
                     handle->sn_coap_tx_callback(response->packet_ptr,
                             response->packet_len, response->address, response->param);
+                } else {
+                    tr_error("sn_coap_protocol_parse - response not yet build");
                 }
             }
 
@@ -2235,6 +2239,20 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 }
 
                 sn_coap_builder_2(dst_ack_packet_data_ptr, src_coap_blockwise_ack_msg_ptr, handle->sn_coap_block_data_size);
+
+#if SN_COAP_DUPLICATION_MAX_MSGS_COUNT
+                // copy coap data buffer to duplicate list for resending purposes
+                if (!sn_coap_protocol_update_duplicate_package_data_all(handle,
+                                                                        src_addr_ptr,
+                                                                        src_coap_blockwise_ack_msg_ptr,
+                                                                        dst_packed_data_needed_mem,
+                                                                        dst_ack_packet_data_ptr)) {
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
+                    handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
+                    return NULL;
+                }
+#endif
+
                 handle->sn_coap_tx_callback(dst_ack_packet_data_ptr, dst_packed_data_needed_mem, src_addr_ptr, param);
 
                 handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
@@ -2434,27 +2452,38 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, const 
 
 #if SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 static bool sn_coap_protocol_update_duplicate_package_data(const struct coap_s *handle,
-                                                        const sn_nsdl_addr_s *dst_addr_ptr,
-                                                        const sn_coap_hdr_s *coap_msg_ptr,
-                                                        const int16_t data_size,
-                                                        const uint8_t *dst_packet_data_ptr)
+                                                           const sn_nsdl_addr_s *dst_addr_ptr,
+                                                           const sn_coap_hdr_s *coap_msg_ptr,
+                                                           const int16_t data_size,
+                                                           const uint8_t *dst_packet_data_ptr)
 {
     if (coap_msg_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT &&
         handle->sn_coap_duplication_buffer_size != 0) {
-        coap_duplication_info_s* info = sn_coap_protocol_linked_list_duplication_info_search(handle,
-                                                                                             dst_addr_ptr,
-                                                                                             coap_msg_ptr->msg_id);
+        return sn_coap_protocol_update_duplicate_package_data_all(handle, dst_addr_ptr, coap_msg_ptr, data_size, dst_packet_data_ptr);
+    }
+    return true;
+}
 
-        /* Update package data to duplication info struct if it's not there yet */
-        if (info && info->packet_ptr == NULL) {
-            info->packet_ptr = handle->sn_coap_protocol_malloc(data_size);
-            if (info->packet_ptr) {
-                memcpy(info->packet_ptr, dst_packet_data_ptr, data_size);
-                info->packet_len = data_size;
-            } else {
-                tr_error("sn_coap_protocol_update_duplication_package_data - failed to allocate duplication info!");
-                return false;
-            }
+static bool sn_coap_protocol_update_duplicate_package_data_all(const struct coap_s *handle,
+                                                               const sn_nsdl_addr_s *dst_addr_ptr,
+                                                               const sn_coap_hdr_s *coap_msg_ptr,
+                                                               const int16_t data_size,
+                                                               const uint8_t *dst_packet_data_ptr)
+{
+    coap_duplication_info_s* info = sn_coap_protocol_linked_list_duplication_info_search(handle,
+                                                                                         dst_addr_ptr,
+                                                                                         coap_msg_ptr->msg_id);
+
+    /* Update package data to duplication info struct if it's not there yet */
+    if (info && info->packet_ptr == NULL) {
+        info->packet_ptr = handle->sn_coap_protocol_malloc(data_size);
+        if (info->packet_ptr) {
+            tr_debug("sn_coap_protocol_update_duplication_package_data - added to duplicate list!");
+            memcpy(info->packet_ptr, dst_packet_data_ptr, data_size);
+            info->packet_len = data_size;
+        } else {
+            tr_error("sn_coap_protocol_update_duplication_package_data - failed to allocate duplication info!");
+            return false;
         }
     }
     return true;

--- a/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/mbed-coap/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -1200,7 +1200,7 @@ void test_block1_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
 
-    retCounter = 7;
+    retCounter = 8;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( ret );
     CHECK(ns_list_count(&handle->linked_list_blockwise_received_payloads) == 0);
@@ -1569,7 +1569,7 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     tmp_hdr.token_ptr = NULL;
     free(dst_packet_data_ptr);
 
-    retCounter = 6;
+    retCounter = 7;
     sn_coap_hdr_s *ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL != ret );
     CHECK( COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status );
@@ -1622,7 +1622,7 @@ void test_block2_receive(struct coap_s *handle, sn_nsdl_addr_s *addr, uint16_t p
     tmp_hdr.token_ptr = NULL;
     free(dst_packet_data_ptr);
 
-    retCounter = 6;
+    retCounter = 7;
     ret = sn_coap_protocol_parse(handle, addr, packet_data_len, packet_data_ptr, NULL);
     CHECK( NULL != ret );
     CHECK( COAP_STATUS_PARSER_BLOCKWISE_ACK == ret->coap_status );


### PR DESCRIPTION
BLOCK2 code-branch was missing handling for duplicate packets. As part of the fix, added also
a call to update the duplicate package data via a new function
sn_coap_protocol_update_duplicate_package_data_all.

The new implementation handles all CoAP messages, not just those with COAP_MSG_TYPE_ACKNOWLEDGEMENT.

Future improvement could optimize the code further to specifically handle what messages get added to
the duplication list, and combine the implementations for update_duplicate_package_data functions.

Fix unit tests for sn_protocol

handle the extra malloc due to change in list update function