### PR TITLE
Clear token if received blockwise message doesn't have one

### DIFF
--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -2217,11 +2217,17 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 */
                 if (src_coap_blockwise_ack_msg_ptr->options_list_ptr &&
                     src_coap_blockwise_ack_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
-                    if (received_coap_msg_ptr->token_len && src_coap_blockwise_ack_msg_ptr->token_ptr) {
+                    if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
                         handle->sn_coap_protocol_free(src_coap_blockwise_ack_msg_ptr->token_ptr);
-                        src_coap_blockwise_ack_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
-                        if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
-                            src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
+                        if (received_coap_msg_ptr->token_len) {
+                            src_coap_blockwise_ack_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, received_coap_msg_ptr->token_ptr, received_coap_msg_ptr->token_len);
+                            if (src_coap_blockwise_ack_msg_ptr->token_ptr) {
+                                src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
+                            }
+                        }
+                        else {
+                            src_coap_blockwise_ack_msg_ptr->token_ptr = NULL;
+                            src_coap_blockwise_ack_msg_ptr->token_len = 0;
                         }
                     }
                 }


### PR DESCRIPTION
[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[x] I confirm the moderators may change the PR before merging it in.

### Summary of changes <!-- Required -->

Clear token if received message doesn't have one. This fix prevents situation where the response is sending token even when it's not required anymore.
