### PR TITLE
Add mapping for retransmission parameters.

### DIFF
--- a/mbed-coap/sn_config.h
+++ b/mbed-coap/sn_config.h
@@ -165,6 +165,10 @@
  * \brief Defines how many times CoAP library tries to re-send the CoAP packet.
  * By default value is 3.
  */
+#ifdef MBED_CONF_MBED_CLIENT_RECONNECTION_COUNT
+#define SN_COAP_RESENDING_MAX_COUNT MBED_CONF_MBED_CLIENT_RECONNECTION_COUNT
+#endif
+
 #ifndef SN_COAP_RESENDING_MAX_COUNT
 #define SN_COAP_RESENDING_MAX_COUNT                     3
 #endif


### PR DESCRIPTION
[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[x] I confirm the moderators may change the PR before merging it in.

### Summary of changes <!-- Required -->

Add mapping between MBED_CONF_MBED_CLIENT_RECONNECTION_COUNT and SN_COAP_RESENDING_MAX_COUNT. This prevents situation where Pelion Device Management Client and Coap library would have different values for retries

