### PR TITLE
Optimise packet parser and builder core

### DIFF
--- a/mbed-coap/sn_coap_header.h
+++ b/mbed-coap/sn_coap_header.h
@@ -23,6 +23,8 @@
 #ifndef SN_COAP_HEADER_H_
 #define SN_COAP_HEADER_H_
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -180,8 +182,8 @@ typedef enum sn_coap_status_ {
  */
 typedef struct sn_coap_options_list_ {
     uint8_t         etag_len;           /**< 1-8 bytes. Repeatable */
-    unsigned int    use_size1:1;
-    unsigned int    use_size2:1;
+    bool            use_size1;
+    bool            use_size2;
 
     uint16_t    proxy_uri_len;      /**< 1-1034 bytes. */
     uint16_t    uri_host_len;       /**< 1-255 bytes. */

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -97,7 +97,7 @@ typedef struct coap_blockwise_payload_ {
 
     uint16_t            payload_len;
     uint8_t             *payload_ptr;
-    unsigned int        use_size1:1;
+    bool                use_size1;
 
     ns_list_link_t     link;
 } coap_blockwise_payload_s;

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -102,7 +102,7 @@ int16_t sn_coap_builder(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_c
     return sn_coap_builder_2(dst_packet_data_ptr, src_coap_msg_ptr, SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE);
 }
 
-int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr, uint16_t blockwise_payload_size)
+int16_t sn_coap_builder_2(uint8_t * restrict dst_packet_data_ptr, const sn_coap_hdr_s * restrict src_coap_msg_ptr, uint16_t blockwise_payload_size)
 {
     uint8_t *base_packet_data_ptr;
 
@@ -203,7 +203,7 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
         /* If options list pointer exists */
         if (src_coap_msg_ptr->options_list_ptr != NULL) {
 
-            const sn_coap_options_list_s *src_options_list_ptr = src_coap_msg_ptr->options_list_ptr;
+            const sn_coap_options_list_s * restrict src_options_list_ptr = src_coap_msg_ptr->options_list_ptr;
 
             /* ACCEPT - An integer option, up to 2 bytes */
             if (src_options_list_ptr->accept != COAP_CT_NONE) {
@@ -500,7 +500,7 @@ static uint_fast8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hd
  *
  * \return Return value is 0 in ok case and -1 in failure case
  **************************************************************************** */
-static uint8_t *sn_coap_builder_header_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
+static uint8_t *sn_coap_builder_header_build(uint8_t * restrict dst_packet_data_ptr, const sn_coap_hdr_s * restrict src_coap_msg_ptr)
 {
     /* * * * Check validity of Header values * * * */
     if (sn_coap_header_validity_check(src_coap_msg_ptr, COAP_VERSION) != 0) {
@@ -535,7 +535,7 @@ static uint8_t *sn_coap_builder_header_build(uint8_t *dst_packet_data_ptr, const
  *
  * \return Returns updated output pointer
  */
-static uint8_t *sn_coap_builder_options_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
+static uint8_t *sn_coap_builder_options_build(uint8_t * restrict dst_packet_data_ptr, const sn_coap_hdr_s * restrict src_coap_msg_ptr)
 {
     /* * * * Check if Options are used at all  * * * */
     if (src_coap_msg_ptr->uri_path_ptr == NULL && src_coap_msg_ptr->token_ptr == NULL &&
@@ -560,7 +560,7 @@ static uint8_t *sn_coap_builder_options_build(uint8_t *dst_packet_data_ptr, cons
 
     //missing: COAP_OPTION_IF_MATCH, COAP_OPTION_IF_NONE_MATCH, COAP_OPTION_SIZE
 
-    const sn_coap_options_list_s *src_options_list_ptr = src_coap_msg_ptr->options_list_ptr;
+    const sn_coap_options_list_s * restrict src_options_list_ptr = src_coap_msg_ptr->options_list_ptr;
 
     /* Check if less used options are used at all */
     if (src_options_list_ptr != NULL) {
@@ -668,8 +668,8 @@ static uint8_t *sn_coap_builder_options_build(uint8_t *dst_packet_data_ptr, cons
  *
  * \return Advanced destination
  */
-static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t *dst_packet_data_ptr, uint16_t option_len,
-        const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number)
+static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t * restrict dst_packet_data_ptr, uint16_t option_len,
+        const uint8_t * restrict option_ptr, sn_coap_option_numbers_e option_number, uint16_t * restrict previous_option_number)
 {
     /* Check if there is option at all */
     if (option_ptr != NULL) {
@@ -764,7 +764,7 @@ static uint_fast8_t sn_coap_builder_options_calc_uint_option_size(uint32_t optio
  *
  * \return Updated destination pointer
  */
-static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t *dst_packet_data_ptr, uint32_t option_value, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number)
+static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t * restrict dst_packet_data_ptr, uint32_t option_value, sn_coap_option_numbers_e option_number, uint16_t * restrict previous_option_number)
 {
     uint8_t payload[4];
     uint_fast8_t len = 0;
@@ -794,11 +794,11 @@ static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t *dst_packe
  *
  * \return Returns updated output pointer
  */
-static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t *dst_packet_data_ptr, const uint8_t *src_pptr, uint16_t src_len, sn_coap_option_numbers_e option, uint16_t *previous_option_number)
+static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t * restrict dst_packet_data_ptr, const uint8_t * restrict src_pptr, uint16_t src_len, sn_coap_option_numbers_e option, uint16_t * restrict previous_option_number)
 {
     /* Check if there is option at all */
     if (src_pptr != NULL) {
-        const uint8_t *query_ptr            = src_pptr;
+        const uint8_t * restrict query_ptr  = src_pptr;
         uint8_t     query_part_count        = 0;
         uint16_t    query_len               = src_len;
         uint8_t     i                       = 0;
@@ -1071,7 +1071,7 @@ static int_fast16_t sn_coap_builder_options_get_option_part_position(uint16_t qu
  *
  * \param *src_coap_msg_ptr is source for building Packet data
  */
-static uint8_t *sn_coap_builder_payload_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
+static uint8_t *sn_coap_builder_payload_build(uint8_t * restrict dst_packet_data_ptr, const sn_coap_hdr_s * restrict src_coap_msg_ptr)
 {
     /* Check if Payload is used at all */
     if (src_coap_msg_ptr->payload_len && src_coap_msg_ptr->payload_ptr != NULL) {

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -37,17 +37,18 @@
 
 #define TRACE_GROUP "coap"
 /* * * * LOCAL FUNCTION PROTOTYPES * * * */
-static int8_t   sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
-static int8_t   sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
+static uint8_t *sn_coap_builder_header_build(uint8_t *dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
+static uint8_t *sn_coap_builder_options_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr);
 static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
-static int16_t  sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet_data_pptr, uint16_t option_len, const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
-static void     sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_packet_data_pptr, const uint8_t *src_pptr, uint16_t src_len_ptr, sn_coap_option_numbers_e option, uint16_t *previous_option_number);
-static uint8_t  sn_coap_builder_options_build_add_uint_option(uint8_t **dst_packet_data_pptr, uint32_t value, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
+static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t *dst_packet_data_ptr, uint16_t option_len, const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
+static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t *dst_packet_data_pptr, const uint8_t *src_pptr, uint16_t src_len_ptr, sn_coap_option_numbers_e option, uint16_t *previous_option_number);
+static uint_fast8_t sn_coap_builder_options_calc_uint_option_size(uint32_t option_value);
+static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t *dst_packet_data_ptr, uint32_t value, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
 static uint8_t  sn_coap_builder_options_get_option_part_count(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
 static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, const uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
-static int16_t  sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
-static void     sn_coap_builder_payload_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
-static uint8_t  sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *src_coap_msg_ptr);
+static int_fast16_t sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
+static uint8_t *sn_coap_builder_payload_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr);
+static uint_fast8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *src_coap_msg_ptr);
 
 sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, const sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
 {
@@ -126,7 +127,8 @@ int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src
     /* * * * * * * * * * * * * * * * * * */
     /* * * * Header part building  * * * */
     /* * * * * * * * * * * * * * * * * * */
-    if (sn_coap_builder_header_build(&dst_packet_data_ptr, src_coap_msg_ptr) != 0) {
+    dst_packet_data_ptr = sn_coap_builder_header_build(dst_packet_data_ptr, src_coap_msg_ptr);
+    if (!dst_packet_data_ptr) {
         /* Header building failed */
         tr_error("sn_coap_builder_2 - header building failed!");
         return -1;
@@ -137,12 +139,12 @@ int16_t sn_coap_builder_2(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src
         /* * * * * * * * * * * * * * * * * * */
         /* * * * Options part building * * * */
         /* * * * * * * * * * * * * * * * * * */
-        sn_coap_builder_options_build(&dst_packet_data_ptr, src_coap_msg_ptr);
+        dst_packet_data_ptr = sn_coap_builder_options_build(dst_packet_data_ptr, src_coap_msg_ptr);
 
         /* * * * * * * * * * * * * * * * * * */
         /* * * * Payload part building * * * */
         /* * * * * * * * * * * * * * * * * * */
-        sn_coap_builder_payload_build(&dst_packet_data_ptr, src_coap_msg_ptr);
+        dst_packet_data_ptr = sn_coap_builder_payload_build(dst_packet_data_ptr, src_coap_msg_ptr);
     }
     /* * * * Return built Packet data length * * * */
     return (dst_packet_data_ptr - base_packet_data_ptr);
@@ -169,7 +171,7 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
 
     /* If else than Reset message because Reset message must be empty */
     if (src_coap_msg_ptr->msg_type != COAP_MSG_TYPE_RESET) {
-        uint16_t repeatable_option_size = 0;
+        uint_fast16_t repeatable_option_size = 0;
         /* TOKEN - Length is 1-8 bytes */
         if (src_coap_msg_ptr->token_ptr != NULL) {
             if (src_coap_msg_ptr->token_len > 8 || src_coap_msg_ptr->token_len < 1) { /* Check that option is not longer than defined */
@@ -190,14 +192,13 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
             }
         }
 
-        uint16_t tempInt = 0;
         /* CONTENT FORMAT - An integer option, up to 2 bytes */
         if (src_coap_msg_ptr->content_format != COAP_CT_NONE) {
             if ((uint32_t) src_coap_msg_ptr->content_format > 0xffff) {
                 tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - content format too large!");
                 return 0;
             }
-            returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_coap_msg_ptr->content_format, COAP_OPTION_CONTENT_FORMAT, &tempInt);
+            returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_coap_msg_ptr->content_format);
         }
         /* If options list pointer exists */
         if (src_coap_msg_ptr->options_list_ptr != NULL) {
@@ -210,11 +211,11 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
                     tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - accept too large!");
                     return 0;
                 }
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->accept, COAP_OPTION_ACCEPT, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->accept);
             }
             /* MAX AGE - An integer option, omitted for default. Up to 4 bytes */
             if (src_options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->max_age, COAP_OPTION_MAX_AGE, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->max_age);
             }
             /* PROXY URI - Length of this option is  1-1034 bytes */
             if (src_options_list_ptr->proxy_uri_ptr != NULL) {
@@ -282,7 +283,7 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
                     tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - uri port too large!");
                     return 0;
                 }
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->uri_port, COAP_OPTION_URI_PORT, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->uri_port);
             }
             /* lOCATION QUERY - Repeatable option. Length of this option is 0-255 bytes */
             if (src_options_list_ptr->location_query_ptr != NULL) {
@@ -300,7 +301,7 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
                 if ((uint32_t) src_options_list_ptr->observe > 0xffffff) {
                     return 0;
                 }
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->observe, COAP_OPTION_OBSERVE, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->observe);
             }
             /* URI QUERY - Repeatable option. Length of this option is 1-255 */
             if (src_options_list_ptr->uri_query_ptr != NULL) {
@@ -320,11 +321,11 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
                     tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - block1 too large!");
                     return 0;
                 }
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->block1, COAP_OPTION_BLOCK1, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->block1);
             }
             /* SIZE1 - Length of this option is 0-4 bytes */
             if (src_options_list_ptr->use_size1) {
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->size1, COAP_OPTION_SIZE1, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->size1);
             }
             /* BLOCK 2 - An integer option, up to 3 bytes */
             if (src_options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE) {
@@ -332,11 +333,11 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
                     tr_error("sn_coap_builder_calc_needed_packet_data_size_2 - block2 too large!");
                     return 0;
                 }
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->block2, COAP_OPTION_BLOCK2, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->block2);
             }
             /* SIZE2 - Length of this option is 0-4 bytes */
             if (src_coap_msg_ptr->options_list_ptr->use_size2) {
-                returned_byte_count += sn_coap_builder_options_build_add_uint_option(NULL, src_options_list_ptr->size2, COAP_OPTION_SIZE2, &tempInt);
+                returned_byte_count += sn_coap_builder_options_calc_uint_option_size(src_options_list_ptr->size2);
             }
         }
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
@@ -374,10 +375,10 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(const sn_coap_hdr_s *src
  * \return Returns bytes needed for jumping
  */
 
-static uint8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *src_coap_msg_ptr)
+static uint_fast8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     uint8_t previous_option_number = 0;
-    uint8_t needed_space           = 0;
+    uint_fast8_t needed_space       = 0;
 
     const sn_coap_options_list_s* options_list_ptr = src_coap_msg_ptr->options_list_ptr;
 
@@ -489,54 +490,52 @@ static uint8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *
 }
 
 /**
- * \fn static int8_t sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr)
+ * \fn static int8_t sn_coap_builder_header_build(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr)
  *
  * \brief Builds Header part of Packet data
  *
- * \param **dst_packet_data_pptr is destination for built Packet data
+ * \param *dst_packet_data_ptr is destination for built Packet data
  *
  * \param *src_coap_msg_ptr is source for building Packet data
  *
  * \return Return value is 0 in ok case and -1 in failure case
  **************************************************************************** */
-static int8_t sn_coap_builder_header_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr)
+static uint8_t *sn_coap_builder_header_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     /* * * * Check validity of Header values * * * */
     if (sn_coap_header_validity_check(src_coap_msg_ptr, COAP_VERSION) != 0) {
         tr_error("sn_coap_builder_header_build - header build failed!");
-        return -1;
+        return NULL;
     }
 
-    uint8_t* dest_packet = *dst_packet_data_pptr;
-
     /* Set CoAP Version, Message type and Token length */
-    dest_packet[0] = COAP_VERSION | src_coap_msg_ptr->msg_type | src_coap_msg_ptr->token_len;
+    dst_packet_data_ptr[0] = COAP_VERSION | src_coap_msg_ptr->msg_type | src_coap_msg_ptr->token_len;
 
     /* * * Add Message code * * */
-    dest_packet[1] = src_coap_msg_ptr->msg_code;
+    dst_packet_data_ptr[1] = src_coap_msg_ptr->msg_code;
 
     /* * * Add Message ID * * */
-    dest_packet[2] = (uint8_t)(src_coap_msg_ptr->msg_id >> COAP_HEADER_MSG_ID_MSB_SHIFT); /* MSB part */
-    dest_packet[3] = (uint8_t)src_coap_msg_ptr->msg_id;                                   /* LSB part */
+    dst_packet_data_ptr[2] = (uint8_t)(src_coap_msg_ptr->msg_id >> COAP_HEADER_MSG_ID_MSB_SHIFT); /* MSB part */
+    dst_packet_data_ptr[3] = (uint8_t)src_coap_msg_ptr->msg_id;                                   /* LSB part */
 
-    *dst_packet_data_pptr = dest_packet + 4;
+    dst_packet_data_ptr += 4;
 
     /* Success */
-    return 0;
+    return dst_packet_data_ptr;
 }
 
 /**
- * \fn static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr)
+ * \fn static int8_t sn_coap_builder_options_build(uint8_t *dst_packet_data_ptr, sn_coap_hdr_s *src_coap_msg_ptr)
  *
  * \brief Builds Options part of Packet data
  *
- * \param **dst_packet_data_pptr is destination for built Packet data
+ * \param *dst_packet_data_ptr is destination for built Packet data
  *
  * \param *src_coap_msg_ptr is source for building Packet data
  *
- * \return Return value is 0 in every case
+ * \return Returns updated output pointer
  */
-static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr)
+static uint8_t *sn_coap_builder_options_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     /* * * * Check if Options are used at all  * * * */
     if (src_coap_msg_ptr->uri_path_ptr == NULL && src_coap_msg_ptr->token_ptr == NULL &&
@@ -545,14 +544,14 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, cons
         if (src_coap_msg_ptr->msg_type != COAP_MSG_TYPE_CONFIRMABLE) {
             tr_error("sn_coap_builder_options_build - options not used!");
         }
-        return 0;
+        return dst_packet_data_ptr;
     }
 
     /* * * * First add Token option  * * * */
     if (src_coap_msg_ptr->token_len && src_coap_msg_ptr->token_ptr) {
-        memcpy(*dst_packet_data_pptr, src_coap_msg_ptr->token_ptr, src_coap_msg_ptr->token_len);
+        memcpy(dst_packet_data_ptr, src_coap_msg_ptr->token_ptr, src_coap_msg_ptr->token_len);
     }
-    (*dst_packet_data_pptr) += src_coap_msg_ptr->token_len;
+    dst_packet_data_ptr += src_coap_msg_ptr->token_len;
 
     /* Then build rest of the options */
 
@@ -566,100 +565,100 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, cons
     /* Check if less used options are used at all */
     if (src_options_list_ptr != NULL) {
         /* * * * Build Uri-Host option * * * */
-        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, src_options_list_ptr->uri_host_len,
+        dst_packet_data_ptr = sn_coap_builder_options_build_add_one_option(dst_packet_data_ptr, src_options_list_ptr->uri_host_len,
                      src_options_list_ptr->uri_host_ptr, COAP_OPTION_URI_HOST, &previous_option_number);
 
         /* * * * Build ETag option  * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->etag_ptr,
+        dst_packet_data_ptr = sn_coap_builder_options_build_add_multiple_option(dst_packet_data_ptr, src_options_list_ptr->etag_ptr,
                      src_options_list_ptr->etag_len, COAP_OPTION_ETAG, &previous_option_number);
 
         /* * * * Build Observe option  * * * * */
         if (src_options_list_ptr->observe != COAP_OBSERVE_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->observe,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->observe,
                          COAP_OPTION_OBSERVE, &previous_option_number);
         }
 
         /* * * * Build Uri-Port option * * * */
         if (src_options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->uri_port,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->uri_port,
                          COAP_OPTION_URI_PORT, &previous_option_number);
         }
 
         /* * * * Build Location-Path option  * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->location_path_ptr,
+        dst_packet_data_ptr = sn_coap_builder_options_build_add_multiple_option(dst_packet_data_ptr, src_options_list_ptr->location_path_ptr,
                      src_options_list_ptr->location_path_len, COAP_OPTION_LOCATION_PATH, &previous_option_number);
     }
     /* * * * Build Uri-Path option * * * */
-    sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_coap_msg_ptr->uri_path_ptr,
+    dst_packet_data_ptr = sn_coap_builder_options_build_add_multiple_option(dst_packet_data_ptr, src_coap_msg_ptr->uri_path_ptr,
              src_coap_msg_ptr->uri_path_len, COAP_OPTION_URI_PATH, &previous_option_number);
 
     /* * * * Build Content-Type option * * * */
     if (src_coap_msg_ptr->content_format != COAP_CT_NONE) {
-        sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_coap_msg_ptr->content_format,
+        dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_coap_msg_ptr->content_format,
                      COAP_OPTION_CONTENT_FORMAT, &previous_option_number);
     }
 
     if (src_options_list_ptr != NULL) {
         /* * * * Build Max-Age option  * * * */
         if (src_options_list_ptr->max_age != COAP_OPTION_MAX_AGE_DEFAULT) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->max_age,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->max_age,
                          COAP_OPTION_MAX_AGE, &previous_option_number);
         }
 
         /* * * * Build Uri-Query option  * * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->uri_query_ptr,
+        dst_packet_data_ptr = sn_coap_builder_options_build_add_multiple_option(dst_packet_data_ptr, src_options_list_ptr->uri_query_ptr,
                      src_options_list_ptr->uri_query_len, COAP_OPTION_URI_QUERY, &previous_option_number);
 
         /* * * * Build Accept option  * * * * */
         if (src_coap_msg_ptr->options_list_ptr->accept != COAP_CT_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->accept,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->accept,
                          COAP_OPTION_ACCEPT, &previous_option_number);
         }
 
         /* * * * Build Location-Query option * * * */
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, src_options_list_ptr->location_query_ptr,
+        dst_packet_data_ptr = sn_coap_builder_options_build_add_multiple_option(dst_packet_data_ptr, src_options_list_ptr->location_query_ptr,
                      src_options_list_ptr->location_query_len, COAP_OPTION_LOCATION_QUERY, &previous_option_number);
 
         /* * * * Build Block2 option * * * * */
         if (src_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->block2,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->block2,
                          COAP_OPTION_BLOCK2, &previous_option_number);
         }
 
         /* * * * Build Block1 option * * * * */
         if (src_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->block1,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->block1,
                          COAP_OPTION_BLOCK1, &previous_option_number);
         }
 
         /* * * * Build Size2 option * * * */
         if (src_coap_msg_ptr->options_list_ptr->use_size2) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->size2,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->size2,
                          COAP_OPTION_SIZE2, &previous_option_number);
         }
 
         /* * * * Build Proxy-Uri option * * * */
-        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, src_options_list_ptr->proxy_uri_len,
+        dst_packet_data_ptr = sn_coap_builder_options_build_add_one_option(dst_packet_data_ptr, src_options_list_ptr->proxy_uri_len,
                      src_options_list_ptr->proxy_uri_ptr, COAP_OPTION_PROXY_URI, &previous_option_number);
 
 
         /* * * * Build Size1 option * * * */
         if (src_options_list_ptr->use_size1) {
-            sn_coap_builder_options_build_add_uint_option(dst_packet_data_pptr, src_options_list_ptr->size1,
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_uint_option(dst_packet_data_ptr, src_options_list_ptr->size1,
                          COAP_OPTION_SIZE1, &previous_option_number);
         }
     }
 
     /* Success */
-    return 0;
+    return dst_packet_data_ptr;
 }
 
 /**
- * \fn static int16_t sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet_data_pptr, uint16_t option_value_len, uint8_t *option_value_ptr, sn_coap_option_numbers_e option_number)
+ * \fn static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t *dst_packet_data_ptr, uint16_t option_value_len, uint8_t *option_value_ptr, sn_coap_option_numbers_e option_number)
  *
  * \brief Adds Options part of Packet data
  *
- * \param **dst_packet_data_pptr is destination for built Packet data
+ * \param *dst_packet_data_ptr is destination for built Packet data
  *
  * \param option_value_len is Option value length to be added
  *
@@ -667,14 +666,14 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, cons
  *
  * \param option_number is Option number to be added
  *
- * \return Return value is 0 if option was not added, 1 if added
+ * \return Advanced destination
  */
-static int16_t sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet_data_pptr, uint16_t option_len,
+static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t *dst_packet_data_ptr, uint16_t option_len,
         const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number)
 {
     /* Check if there is option at all */
     if (option_ptr != NULL) {
-        uint16_t option_delta;
+        uint_fast16_t option_delta;
 
         option_delta = (option_number - *previous_option_number);
 
@@ -695,76 +694,80 @@ static int16_t sn_coap_builder_options_build_add_one_option(uint8_t **dst_packet
             first_byte = 0x0E;
         }
 
-        uint8_t *dest_packet = *dst_packet_data_pptr;
-
         /* Then option delta with extensions, and move pointer */
         if (option_delta <= 12) {
-            dest_packet[0] = first_byte + (option_delta << 4);
-            dest_packet += 1;
+            *dst_packet_data_ptr++ = first_byte + (option_delta << 4);
         }
 
         else if (option_delta > 12 && option_delta < 269) {
-            dest_packet[0] = first_byte + 0xD0;
+            *dst_packet_data_ptr++ = first_byte + 0xD0;
             option_delta -= 13;
 
-            dest_packet[1] = (uint8_t)option_delta;
-            dest_packet += 2;
+            *dst_packet_data_ptr++ = (uint8_t)option_delta;
         }
         //This is currently dead code (but possibly needed in future)
         else /*if (option_delta >= 269)*/ {
-            dest_packet[0] = first_byte + 0xE0;
+            *dst_packet_data_ptr++ = first_byte + 0xE0;
             option_delta -= 269;
 
-            dest_packet[1] = (option_delta >> 8);
-            dest_packet[2] = (uint8_t)option_delta;
-            dest_packet += 3;
+            *dst_packet_data_ptr++ = (option_delta >> 8);
+            *dst_packet_data_ptr++ = (uint8_t)option_delta;
         }
 
         /* Now option length extensions, if needed */
         if (option_len > 12 && option_len < 269) {
-            dest_packet[0] = (uint8_t)(option_len - 13);
-            dest_packet += 1;
+            *dst_packet_data_ptr++ = (uint8_t)(option_len - 13);
         }
 
         else if (option_len >= 269) {
-            dest_packet[0] = ((option_len - 269) >> 8);
-            dest_packet[1] = (uint8_t)(option_len - 269);
-            dest_packet += 2;
+            *dst_packet_data_ptr++ = ((option_len - 269) >> 8);
+            *dst_packet_data_ptr++ = (uint8_t)(option_len - 269);
         }
 
         *previous_option_number = option_number;
 
         /* Write Option value */
-        memcpy(dest_packet, option_ptr, option_len);
+        memcpy(dst_packet_data_ptr, option_ptr, option_len);
 
         /* Increase destination Packet data pointer */
-        dest_packet += option_len;
-
-        *dst_packet_data_pptr = dest_packet;
-
-        return 1;
+        dst_packet_data_ptr += option_len;
     }
 
     /* Success */
-    return 0;
+    return dst_packet_data_ptr;
+}
+
+static uint_fast8_t sn_coap_builder_options_calc_uint_option_size(uint32_t option_value)
+{
+    // Calculation assumes option type/len is always 1 byte.
+    // Length certainly fits, and any extra for option type is accounted for
+    // separately by sn_coap_builder_options_calculate_jump_need.
+    uint_fast8_t len = 1;
+
+    while (option_value != 0) {
+        len++;
+        option_value >>= 8;
+    }
+
+    return len;
 }
 
 /**
  * \brief Constructs a uint Options part of Packet data
  *
- * \param **dst_packet_data_pptr is destination for built Packet data; NULL
+ * \param *dst_packet_data_pptr is destination for built Packet data; NULL
  *        to compute size only.
  *
  * \param option_value is Option value to be added
  *
  * \param option_number is Option number to be added
  *
- * \return Return value is total option size, or -1 in write failure case
+ * \return Updated destination pointer
  */
-static uint8_t sn_coap_builder_options_build_add_uint_option(uint8_t **dst_packet_data_pptr, uint32_t option_value, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number)
+static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t *dst_packet_data_ptr, uint32_t option_value, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number)
 {
     uint8_t payload[4];
-    uint8_t len = 0;
+    uint_fast8_t len = 0;
     /* Construct the variable-length payload representing the value */
     for (uint8_t i = 0; i < 4; i++) {
         if (len > 0 || (option_value & 0xff000000)) {
@@ -773,23 +776,15 @@ static uint8_t sn_coap_builder_options_build_add_uint_option(uint8_t **dst_packe
         option_value <<= 8;
     }
 
-    /* If output pointer isn't NULL, write it out */
-    if (dst_packet_data_pptr) {
-        // No need to check & handle return value, as the function returns failure only if the option pointer is zero
-        // and it is pointing to a local variable here.
-        sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, len, payload, option_number, previous_option_number);
-    }
-
-    /* Return the total option size */
-    return 1 + len;
+    return sn_coap_builder_options_build_add_one_option(dst_packet_data_ptr, len, payload, option_number, previous_option_number);
 }
 
 /**
- * \fn static int16_t sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_packet_data_pptr, uint8_t **src_pptr, uint16_t *src_len_ptr, sn_coap_option_numbers_e option)
+ * \fn static int16_t sn_coap_builder_options_build_add_multiple_option(uint8_t *dst_packet_data_pptr, uint8_t **src_pptr, uint16_t *src_len_ptr, sn_coap_option_numbers_e option)
  *
  * \brief Builds Option Uri-Query from given CoAP Header structure to Packet data
  *
- * \param **dst_packet_data_pptr is destination for built Packet data
+ * \param *dst_packet_data_ptr is destination for built Packet data
  *
  * \param uint8_t **src_ptr
  *
@@ -797,9 +792,9 @@ static uint8_t sn_coap_builder_options_build_add_uint_option(uint8_t **dst_packe
  *
  *  \paramsn_coap_option_numbers_e option option to be added
  *
- * \return Return value is 0 always
+ * \return Returns updated output pointer
  */
-static void sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_packet_data_pptr, const uint8_t *src_pptr, uint16_t src_len, sn_coap_option_numbers_e option, uint16_t *previous_option_number)
+static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t *dst_packet_data_ptr, const uint8_t *src_pptr, uint16_t src_len, sn_coap_option_numbers_e option, uint16_t *previous_option_number)
 {
     /* Check if there is option at all */
     if (src_pptr != NULL) {
@@ -807,7 +802,7 @@ static void sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_pack
         uint8_t     query_part_count        = 0;
         uint16_t    query_len               = src_len;
         uint8_t     i                       = 0;
-        uint16_t    query_part_offset       = 0;
+        uint_fast16_t query_part_offset     = 0;
 
         /* Get query part count */
         query_part_count = sn_coap_builder_options_get_option_part_count(query_len, query_ptr, option);
@@ -821,10 +816,11 @@ static void sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_pack
             query_part_offset = sn_coap_builder_options_get_option_part_position(query_len, query_ptr, i, option);
 
             /* Add Uri-query's one part to Options */
-            sn_coap_builder_options_build_add_one_option(dst_packet_data_pptr, one_query_part_len, src_pptr + query_part_offset, option, previous_option_number);
+            dst_packet_data_ptr = sn_coap_builder_options_build_add_one_option(dst_packet_data_ptr, one_query_part_len, src_pptr + query_part_offset, option, previous_option_number);
         }
     }
     /* Success */
+    return dst_packet_data_ptr;
 }
 
 
@@ -841,9 +837,9 @@ static void sn_coap_builder_options_build_add_multiple_option(uint8_t **dst_pack
  */
 static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
 {
-    uint8_t     query_part_count    = sn_coap_builder_options_get_option_part_count(query_len, query_ptr, option);
-    uint8_t     i                   = 0;
-    uint16_t    ret_value           = 0;
+    uint8_t       query_part_count  = sn_coap_builder_options_get_option_part_count(query_len, query_ptr, option);
+    uint_fast8_t  i                 = 0;
+    uint_fast16_t ret_value         = 0;
 
     /* * * * * * * * * * * * * * * * * * * * * * * * */
     /* * * * Calculate Uri-query options length  * * */
@@ -922,23 +918,25 @@ static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, con
  */
 static uint8_t sn_coap_builder_options_get_option_part_count(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
 {
-    uint8_t  returned_query_count = 0;
-    uint16_t query_len_index      = 0;
-    uint8_t  char_to_search       = '&';
+    if (query_len <= 2) {
+        return 1;
+    }
+
+    const uint8_t *query_end           = query_ptr + query_len - 1;
+    uint8_t       char_to_search       = '&';
 
     if (option == COAP_OPTION_URI_PATH || option == COAP_OPTION_LOCATION_PATH) {
         char_to_search = '/';
     }
 
     /* Loop whole query and search '\0' characters (not first and last char) */
-    for (query_len_index = 1; query_len_index < query_len - 1; query_len_index++) {
-        /* If new query part starts */
-        if (*(query_ptr + query_len_index) == char_to_search) { /* If match */
+    uint_fast8_t  returned_query_count = 1;
+    query_ptr++;
+    do {
+        if (*query_ptr++ == char_to_search) { /* If match */
             returned_query_count++;
         }
-    }
-
-    returned_query_count++;
+    } while (query_ptr < query_end);
 
     return returned_query_count;
 }
@@ -963,10 +961,10 @@ static uint8_t sn_coap_builder_options_get_option_part_count(uint16_t query_len,
 static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, const uint8_t *query_ptr,
         uint8_t query_index, sn_coap_option_numbers_e option)
 {
-    uint16_t returned_query_part_len = 0;
-    uint8_t  temp_query_index        = 0;
-    uint16_t query_len_index         = 0;
-    uint8_t  char_to_search          = '&';
+    uint_fast16_t returned_query_part_len = 0;
+    uint_fast8_t  temp_query_index        = 0;
+    uint_fast16_t query_len_index         = 0;
+    uint_fast8_t  char_to_search          = '&';
 
     if (option == COAP_OPTION_URI_PATH || option == COAP_OPTION_LOCATION_PATH) {
         char_to_search = '/';
@@ -975,7 +973,7 @@ static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option
     /* Loop whole query and search '\0' characters */
     for (query_len_index = 0; query_len_index < query_len; query_len_index++) {
         /* Store character to temp_char for helping debugging */
-        uint8_t temp_char = *query_ptr;
+        uint_fast8_t temp_char = *query_ptr;
 
         /* If new query part starts */
         if (temp_char == char_to_search && returned_query_part_len > 0) { /* returned_query_part_len > 0 is for querys which start with "\0" */
@@ -1018,13 +1016,13 @@ static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option
  * \return Return value is position (= offset) of query part in whole query. In
  *         fail cases -1 is returned.
  */
-static int16_t sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr,
+static int_fast16_t sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr,
         uint8_t query_index, sn_coap_option_numbers_e option)
 {
-    uint16_t returned_query_part_offset = 0;
-    uint8_t  temp_query_index           = 0;
-    uint16_t query_len_index            = 0;
-    uint8_t  char_to_search             = '&';
+    uint_fast16_t returned_query_part_offset = 0;
+    uint_fast8_t  temp_query_index           = 0;
+    uint_fast16_t query_len_index            = 0;
+    uint_fast8_t  char_to_search             = '&';
 
     if (option == COAP_OPTION_URI_PATH || option == COAP_OPTION_LOCATION_PATH) {
         char_to_search = '/';
@@ -1041,7 +1039,7 @@ static int16_t sn_coap_builder_options_get_option_part_position(uint16_t query_l
     /* Loop whole query and search separator characters */
     for (query_len_index = 0; query_len_index < query_len; query_len_index++) {
         /* Store character to temp_char for helping debugging */
-        uint8_t temp_char = *query_ptr;
+        uint_fast8_t temp_char = *query_ptr;
 
         /* If new query part starts */
         if (temp_char == char_to_search && returned_query_part_offset > 0) { /* returned_query_part_offset > 0 is for querys which start with searched char */
@@ -1065,27 +1063,28 @@ static int16_t sn_coap_builder_options_get_option_part_position(uint16_t query_l
 
 
 /**
- * \fn static void sn_coap_builder_payload_build(uint8_t **dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr)
+ * \fn static void sn_coap_builder_payload_build(uint8_t *dst_packet_data_pptr, sn_coap_hdr_s *src_coap_msg_ptr)
  *
  * \brief Builds Options part of Packet data
  *
- * \param **dst_packet_data_pptr is destination for built Packet data
+ * \param *dst_packet_data_ptr is destination for built Packet data
  *
  * \param *src_coap_msg_ptr is source for building Packet data
  */
-static void sn_coap_builder_payload_build(uint8_t **dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr)
+static uint8_t *sn_coap_builder_payload_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr)
 {
     /* Check if Payload is used at all */
     if (src_coap_msg_ptr->payload_len && src_coap_msg_ptr->payload_ptr != NULL) {
         /* Write Payload marker */
 
-        **dst_packet_data_pptr = 0xff;
-        (*dst_packet_data_pptr)++;
+        *dst_packet_data_ptr++ = 0xff;
 
         /* Write Payload */
-        memcpy(*dst_packet_data_pptr, src_coap_msg_ptr->payload_ptr, src_coap_msg_ptr->payload_len);
+        memcpy(dst_packet_data_ptr, src_coap_msg_ptr->payload_ptr, src_coap_msg_ptr->payload_len);
 
         /* Increase destination Packet data pointer */
-        (*dst_packet_data_pptr) += src_coap_msg_ptr->payload_len;
+        dst_packet_data_ptr += src_coap_msg_ptr->payload_len;
     }
+
+    return dst_packet_data_ptr;
 }

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -42,11 +42,11 @@
 /* * * * LOCAL FUNCTION PROTOTYPES * * * */
 /* * * * * * * * * * * * * * * * * * * * */
 
-static void     sn_coap_parser_header_parse(uint8_t **packet_data_pptr, sn_coap_hdr_s *dst_coap_msg_ptr, coap_version_e *coap_version_ptr);
-static int8_t   sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **packet_data_pptr, sn_coap_hdr_s *dst_coap_msg_ptr, uint8_t *packet_data_start_ptr, uint16_t packet_len);
-static int8_t   sn_coap_parser_options_parse_multiple_options(struct coap_s *handle, uint8_t **packet_data_pptr, uint16_t packet_left_len,  uint8_t **dst_pptr, uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len);
-static int16_t  sn_coap_parser_options_count_needed_memory_multiple_option(uint8_t *packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len);
-static int8_t   sn_coap_parser_payload_parse(uint16_t packet_data_len, uint8_t *packet_data_start_ptr, uint8_t **packet_data_pptr, sn_coap_hdr_s *dst_coap_msg_ptr);
+static const uint8_t *sn_coap_parser_header_parse(const uint8_t *packet_data_ptr, sn_coap_hdr_s *dst_coap_msg_ptr, coap_version_e *coap_version_ptr);
+static const uint8_t *sn_coap_parser_options_parse(const uint8_t *packet_data_ptr, struct coap_s *handle, sn_coap_hdr_s *dst_coap_msg_ptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len);
+static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t *packet_data_ptr, struct coap_s *handle, uint16_t packet_left_len,  uint8_t **dst_pptr, uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len);
+static int            sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t *packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len);
+static const uint8_t *sn_coap_parser_payload_parse(const uint8_t *packet_data_ptr, uint16_t packet_data_len, uint8_t *packet_data_start_ptr, sn_coap_hdr_s *dst_coap_msg_ptr);
 
 sn_coap_hdr_s *sn_coap_parser_init_message(sn_coap_hdr_s *coap_msg_ptr)
 {
@@ -138,7 +138,7 @@ sn_coap_options_list_s *sn_coap_parser_alloc_options(struct coap_s *handle, sn_c
 
 sn_coap_hdr_s *sn_coap_parser(struct coap_s *handle, uint16_t packet_data_len, uint8_t *packet_data_ptr, coap_version_e *coap_version_ptr)
 {
-    uint8_t       *data_temp_ptr                    = packet_data_ptr;
+    const uint8_t *data_temp_ptr                    = packet_data_ptr;
     sn_coap_hdr_s *parsed_and_returned_coap_msg_ptr = NULL;
 
     /* * * * Check given pointer * * * */
@@ -155,15 +155,18 @@ sn_coap_hdr_s *sn_coap_parser(struct coap_s *handle, uint16_t packet_data_len, u
     }
 
     /* * * * Header parsing, move pointer over the header...  * * * */
-    sn_coap_parser_header_parse(&data_temp_ptr, parsed_and_returned_coap_msg_ptr, coap_version_ptr);
+    data_temp_ptr = sn_coap_parser_header_parse(data_temp_ptr, parsed_and_returned_coap_msg_ptr, coap_version_ptr);
+
     /* * * * Options parsing, move pointer over the options... * * * */
-    if (sn_coap_parser_options_parse(handle, &data_temp_ptr, parsed_and_returned_coap_msg_ptr, packet_data_ptr, packet_data_len) != 0) {
+    data_temp_ptr = sn_coap_parser_options_parse(data_temp_ptr, handle, parsed_and_returned_coap_msg_ptr, packet_data_ptr, packet_data_len);
+    if (!data_temp_ptr) {
         parsed_and_returned_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_ERROR_IN_HEADER;
         return parsed_and_returned_coap_msg_ptr;
     }
 
     /* * * * Payload parsing * * * */
-    if (sn_coap_parser_payload_parse(packet_data_len, packet_data_ptr, &data_temp_ptr, parsed_and_returned_coap_msg_ptr) == -1) {
+    data_temp_ptr = sn_coap_parser_payload_parse(data_temp_ptr, packet_data_len, packet_data_ptr, parsed_and_returned_coap_msg_ptr);
+    if (!data_temp_ptr) {
         parsed_and_returned_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_ERROR_IN_HEADER;
         return parsed_and_returned_coap_msg_ptr;
     }
@@ -224,22 +227,20 @@ void sn_coap_parser_release_allocated_coap_msg_mem(struct coap_s *handle, sn_coa
  *
  * \param *coap_version_ptr is destination for parsed CoAP specification version
  */
-static void sn_coap_parser_header_parse(uint8_t **packet_data_pptr, sn_coap_hdr_s *dst_coap_msg_ptr, coap_version_e *coap_version_ptr)
+static const uint8_t *sn_coap_parser_header_parse(const uint8_t *packet_data_ptr, sn_coap_hdr_s *dst_coap_msg_ptr, coap_version_e *coap_version_ptr)
 {
     /* Parse CoAP Version and message type*/
-    *coap_version_ptr = (coap_version_e)(**packet_data_pptr & COAP_HEADER_VERSION_MASK);
-    dst_coap_msg_ptr->msg_type = (sn_coap_msg_type_e)(**packet_data_pptr & COAP_HEADER_MSG_TYPE_MASK);
-    (*packet_data_pptr) += 1;
+    *coap_version_ptr = (coap_version_e)(*packet_data_ptr & COAP_HEADER_VERSION_MASK);
+    dst_coap_msg_ptr->msg_type = (sn_coap_msg_type_e)(*packet_data_ptr++ & COAP_HEADER_MSG_TYPE_MASK);
 
     /* Parse Message code */
-    dst_coap_msg_ptr->msg_code = (sn_coap_msg_code_e) **packet_data_pptr;
-    (*packet_data_pptr) += 1;
+    dst_coap_msg_ptr->msg_code = (sn_coap_msg_code_e) *packet_data_ptr++;
 
     /* Parse Message ID */
-    dst_coap_msg_ptr->msg_id = *(*packet_data_pptr + 1);
-    dst_coap_msg_ptr->msg_id += **packet_data_pptr << COAP_HEADER_MSG_ID_MSB_SHIFT;
-    (*packet_data_pptr) += 2;
+    dst_coap_msg_ptr->msg_id = *packet_data_ptr++ << COAP_HEADER_MSG_ID_MSB_SHIFT;
+    dst_coap_msg_ptr->msg_id |= *packet_data_ptr++;
 
+    return packet_data_ptr;
 }
 
 /**
@@ -250,13 +251,15 @@ static void sn_coap_parser_header_parse(uint8_t **packet_data_pptr, sn_coap_hdr_
  *
  * \return Return value is value of uint
  */
-static uint32_t sn_coap_parser_options_parse_uint(uint8_t **packet_data_pptr, uint8_t option_len)
+static uint32_t sn_coap_parser_options_parse_uint(const uint8_t **packet_data_pptr, uint8_t option_len)
 {
     uint32_t value = 0;
+    const uint8_t *packet_data_ptr = *packet_data_pptr;
     while (option_len--) {
         value <<= 8;
-        value |= *(*packet_data_pptr)++;
+        value |= *packet_data_ptr++;
     }
+    *packet_data_pptr = packet_data_ptr;
     return value;
 }
 
@@ -293,10 +296,10 @@ static int8_t sn_coap_parser_add_u16_limit(uint16_t a, uint16_t b, uint16_t *res
  *
  * \return Return 0 if the data is within the bounds, -1 otherwise
  */
-static int8_t sn_coap_parser_check_packet_ptr(uint8_t *packet_data_ptr, uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
+static int8_t sn_coap_parser_check_packet_ptr(const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
 {
-    uint8_t *packet_end = packet_data_start_ptr + packet_len;
-    uint8_t *new_data_ptr = packet_data_ptr + delta;
+    const uint8_t *packet_end = packet_data_start_ptr + packet_len;
+    const uint8_t *new_data_ptr = packet_data_ptr + delta;
 
     if (delta > packet_len) {
         return -1;
@@ -319,10 +322,10 @@ static int8_t sn_coap_parser_check_packet_ptr(uint8_t *packet_data_ptr, uint8_t 
  *
  * \return Return The remaining packet data length
  */
-static uint16_t sn_coap_parser_move_packet_ptr(uint8_t **packet_data_pptr, uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
+static uint16_t sn_coap_parser_move_packet_ptr(const uint8_t **packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
 {
-    uint8_t *packet_end = packet_data_start_ptr + packet_len;
-    uint8_t *new_data_ptr = *packet_data_pptr + delta;
+    const uint8_t *packet_end = packet_data_start_ptr + packet_len;
+    const uint8_t *new_data_ptr = *packet_data_pptr + delta;
 
     if (new_data_ptr < packet_data_start_ptr) {
         return 0;
@@ -346,7 +349,7 @@ static uint16_t sn_coap_parser_move_packet_ptr(uint8_t **packet_data_pptr, uint8
  *
  * \return Return 0 if the data is within the bounds, -1 otherwise
  */
-static int8_t sn_coap_parser_read_packet_u8(uint8_t *dst, uint8_t *packet_data_ptr, uint8_t *packet_data_start_ptr, uint16_t packet_len)
+static int8_t sn_coap_parser_read_packet_u8(uint8_t *dst, const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len)
 {
     int8_t ptr_check_result;
 
@@ -373,7 +376,7 @@ static int8_t sn_coap_parser_read_packet_u8(uint8_t *dst, uint8_t *packet_data_p
  *
  * \return Return 0 if the data is within the bounds, -1 otherwise
  */
-static int8_t sn_coap_parser_read_packet_u16(uint16_t *dst, uint8_t *packet_data_ptr, uint8_t *packet_data_start_ptr, uint16_t packet_len)
+static int8_t sn_coap_parser_read_packet_u16(uint16_t *dst, const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len)
 {
     int8_t ptr_check_result;
     uint16_t value;
@@ -402,7 +405,7 @@ static int8_t sn_coap_parser_read_packet_u16(uint16_t *dst, uint8_t *packet_data
  *
  * \return Return 0 if the read was successful, -1 otherwise
  */
-static int8_t parse_ext_option(uint16_t *dst, uint8_t **packet_data_pptr, uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t *message_left)
+static int8_t parse_ext_option(uint16_t *dst, const uint8_t **packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint_fast16_t *message_left)
 {
     uint16_t option_number = *dst;
 
@@ -449,16 +452,15 @@ static int8_t parse_ext_option(uint16_t *dst, uint8_t **packet_data_pptr, uint8_
  *
  * \brief Parses CoAP message's Options part from given Packet data
  *
- * \param **packet_data_pptr is source of Packet data to be parsed to CoAP message
+ * \param *packet_data_ptr is source of Packet data to be parsed to CoAP message
  * \param *dst_coap_msg_ptr is destination for parsed CoAP message
  *
- * \return Return value is 0 in ok case and -1 in failure case
+ * \return Return value is advanced input pointer in ok case and NULL in failure case
  */
-static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **packet_data_pptr, sn_coap_hdr_s *dst_coap_msg_ptr, uint8_t *packet_data_start_ptr, uint16_t packet_len)
+static const uint8_t * sn_coap_parser_options_parse(const uint8_t *packet_data_ptr, struct coap_s *handle, sn_coap_hdr_s *dst_coap_msg_ptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len)
 {
-    uint8_t  previous_option_number = 0;
-    int8_t   ret_status             = 0;
-    uint16_t message_left           = sn_coap_parser_move_packet_ptr(packet_data_pptr, packet_data_start_ptr, packet_len, 0);
+    uint_fast16_t previous_option_number = 0;
+    uint_fast16_t message_left           = sn_coap_parser_move_packet_ptr(&packet_data_ptr, packet_data_start_ptr, packet_len, 0);
 
     /*  Parse token, if exists  */
     dst_coap_msg_ptr->token_len = *packet_data_start_ptr & COAP_HEADER_TOKEN_LENGTH_MASK;
@@ -467,49 +469,50 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
         int8_t ptr_check_result;
         if ((dst_coap_msg_ptr->token_len > 8) || dst_coap_msg_ptr->token_ptr) {
             tr_error("sn_coap_parser_options_parse - token not valid!");
-            return -1;
+            return NULL;
         }
 
-        ptr_check_result = sn_coap_parser_check_packet_ptr(*packet_data_pptr, packet_data_start_ptr, packet_len, dst_coap_msg_ptr->token_len);
+        ptr_check_result = sn_coap_parser_check_packet_ptr(packet_data_ptr, packet_data_start_ptr, packet_len, dst_coap_msg_ptr->token_len);
         if (0 != ptr_check_result) {
-            tr_error("sn_coap_parser_options_parse - **packet_data_pptr overflow !");
-            return -1;
+            tr_error("sn_coap_parser_options_parse - *packet_data_ptr overflow !");
+            return NULL;
         }
 
-        dst_coap_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, *packet_data_pptr, dst_coap_msg_ptr->token_len);
+        dst_coap_msg_ptr->token_ptr = sn_coap_protocol_malloc_copy(handle, packet_data_ptr, dst_coap_msg_ptr->token_len);
 
         if (dst_coap_msg_ptr->token_ptr == NULL) {
             tr_error("sn_coap_parser_options_parse - failed to allocate token!");
-            return -1;
+            return NULL;
         }
 
-        message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, packet_data_start_ptr, packet_len, dst_coap_msg_ptr->token_len);
+        message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, packet_data_start_ptr, packet_len, dst_coap_msg_ptr->token_len);
     }
 
+    message_left = packet_len - (packet_data_ptr - packet_data_start_ptr);
+
     /* Loop all Options */
-    while (message_left && (**packet_data_pptr != 0xff)) {
+    while (message_left && (*packet_data_ptr != 0xff)) {
         /* Get option length WITHOUT extensions */
-        uint16_t option_len = (**packet_data_pptr & 0x0F);
+        uint16_t option_len = (*packet_data_ptr & 0x0F);
         /* Get option number WITHOUT extensions */
-        uint16_t  option_number = (**packet_data_pptr >> COAP_OPTIONS_OPTION_NUMBER_SHIFT);
+        uint16_t option_number = (*packet_data_ptr >> COAP_OPTIONS_OPTION_NUMBER_SHIFT);
 
-        message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, packet_data_start_ptr, packet_len, 1);
-
+        message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, packet_data_start_ptr, packet_len, 1);
         int8_t    option_parse_result;
         /* Add possible option delta extension */
-        option_parse_result = parse_ext_option(&option_number, packet_data_pptr, packet_data_start_ptr, packet_len, &message_left);
+        option_parse_result = parse_ext_option(&option_number, &packet_data_ptr, packet_data_start_ptr, packet_len, &message_left);
         if (option_parse_result != 0) {
-            return -1;
+            return NULL;
         }
         /* Add previous option to option delta and get option number */
         if (sn_coap_parser_add_u16_limit(option_number, previous_option_number, &option_number) != 0) {
-            return -1;
+            return NULL;
         }
 
         /* Add possible option length extension to resolve full length of the option */
-        option_parse_result = parse_ext_option(&option_len, packet_data_pptr, packet_data_start_ptr, packet_len, &message_left);
+        option_parse_result = parse_ext_option(&option_len, &packet_data_ptr, packet_data_start_ptr, packet_len, &message_left);
         if (option_parse_result != 0) {
-            return -1;
+            return NULL;
         }
 
         /* * * Parse option itself * * */
@@ -533,15 +536,15 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
             case COAP_OPTION_SIZE2:
                 if (sn_coap_parser_alloc_options(handle, dst_coap_msg_ptr) == NULL) {
                     tr_error("sn_coap_parser_options_parse - failed to allocate options!");
-                    return -1;
+                    return NULL;
                 }
                 break;
         }
 
         if (message_left < option_len){
-            /* packet_data_pptr would overflow! */
-            tr_error("sn_coap_parser_options_parse - **packet_data_pptr would overflow when parsing options!");
-            return -1;
+            /* packet_data_ptr would overflow! */
+            tr_error("sn_coap_parser_options_parse - *packet_data_ptr would overflow when parsing options!");
+            return NULL;
         }
 
         /* Parse option */
@@ -549,100 +552,100 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
             case COAP_OPTION_CONTENT_FORMAT:
                 if ((option_len > 2) || (dst_coap_msg_ptr->content_format != COAP_CT_NONE)) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_CONTENT_FORMAT not valid!");
-                    return -1;
+                    return NULL;
                 }
-                dst_coap_msg_ptr->content_format = (sn_coap_content_format_e) sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->content_format = (sn_coap_content_format_e) sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_MAX_AGE:
                 if (option_len > 4) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_MAX_AGE not valid!");
-                    return -1;
+                    return NULL;
                 }
-                dst_coap_msg_ptr->options_list_ptr->max_age = sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->max_age = sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_PROXY_URI:
                 if ((option_len > 1034) || (option_len < 1) || dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_PROXY_URI not valid!");
-                    return -1;
+                    return NULL;
                 }
                 dst_coap_msg_ptr->options_list_ptr->proxy_uri_len = option_len;
-                dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr = sn_coap_protocol_malloc_copy(handle, *packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr = sn_coap_protocol_malloc_copy(handle, packet_data_ptr, option_len);
 
                 if (dst_coap_msg_ptr->options_list_ptr->proxy_uri_ptr == NULL) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_PROXY_URI allocation failed!");
-                    return -1;
+                    return NULL;
                 }
-                message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, packet_data_start_ptr, packet_len, option_len);
+                message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, packet_data_start_ptr, packet_len, option_len);
                 break;
 
             case COAP_OPTION_ETAG:
                 if (dst_coap_msg_ptr->options_list_ptr->etag_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_ETAG exists!");
-                    return -1;
+                    return NULL;
                 }
                 /* This is managed independently because User gives this option in one character table */
-                ret_status = sn_coap_parser_options_parse_multiple_options(handle, packet_data_pptr,
+                packet_data_ptr = sn_coap_parser_options_parse_multiple_options(packet_data_ptr, handle,
                              message_left,
                              &dst_coap_msg_ptr->options_list_ptr->etag_ptr,
                              (uint16_t *)&dst_coap_msg_ptr->options_list_ptr->etag_len,
                              COAP_OPTION_ETAG, option_len);
-                if (ret_status < 0) {
+                if (!packet_data_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_ETAG not valid!");
-                    return -1;
+                    return NULL;
                 }
                 break;
 
             case COAP_OPTION_URI_HOST:
                 if ((option_len > 255) || (option_len < 1) || dst_coap_msg_ptr->options_list_ptr->uri_host_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_URI_HOST not valid!");
-                    return -1;
+                    return NULL;
                 }
                 dst_coap_msg_ptr->options_list_ptr->uri_host_len = option_len;
-                dst_coap_msg_ptr->options_list_ptr->uri_host_ptr = sn_coap_protocol_malloc_copy(handle, *packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->uri_host_ptr = sn_coap_protocol_malloc_copy(handle, packet_data_ptr, option_len);
 
                 if (dst_coap_msg_ptr->options_list_ptr->uri_host_ptr == NULL) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_URI_HOST allocation failed!");
-                    return -1;
+                    return NULL;
                 }
-                message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, packet_data_start_ptr, packet_len, option_len);
+                message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, packet_data_start_ptr, packet_len, option_len);
                 break;
 
             case COAP_OPTION_LOCATION_PATH:
                 if (dst_coap_msg_ptr->options_list_ptr->location_path_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_LOCATION_PATH exists!");
-                    return -1;
+                    return NULL;
                 }
                 /* This is managed independently because User gives this option in one character table */
-                ret_status = sn_coap_parser_options_parse_multiple_options(handle, packet_data_pptr, message_left,
+                packet_data_ptr = sn_coap_parser_options_parse_multiple_options(packet_data_ptr, handle, message_left,
                              &dst_coap_msg_ptr->options_list_ptr->location_path_ptr, &dst_coap_msg_ptr->options_list_ptr->location_path_len,
                              COAP_OPTION_LOCATION_PATH, option_len);
-                if (ret_status < 0) {
+                if (!packet_data_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_LOCATION_PATH not valid!");
-                    return -1;
+                    return NULL;
                 }
                 break;
 
             case COAP_OPTION_URI_PORT:
                 if ((option_len > 2) || dst_coap_msg_ptr->options_list_ptr->uri_port != COAP_OPTION_URI_PORT_NONE) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_URI_PORT not valid!");
-                    return -1;
+                    return NULL;
                 }
-                dst_coap_msg_ptr->options_list_ptr->uri_port = sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->uri_port = sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_LOCATION_QUERY:
                 if (dst_coap_msg_ptr->options_list_ptr->location_query_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_LOCATION_QUERY exists!");
-                    return -1;
+                    return NULL;
                 }
-                ret_status = sn_coap_parser_options_parse_multiple_options(handle, packet_data_pptr, message_left,
+                packet_data_ptr = sn_coap_parser_options_parse_multiple_options(packet_data_ptr, handle, message_left,
                              &dst_coap_msg_ptr->options_list_ptr->location_query_ptr, &dst_coap_msg_ptr->options_list_ptr->location_query_len,
                              COAP_OPTION_LOCATION_QUERY, option_len);
-                if (ret_status < 0) {
+                if (!packet_data_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_LOCATION_QUERY not valid!");
-                    return -1;
+                    return NULL;
                 }
 
                 break;
@@ -650,99 +653,99 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
             case COAP_OPTION_URI_PATH:
                 if (dst_coap_msg_ptr->uri_path_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_URI_PATH exists!");
-                    return -1;
+                    return NULL;
                 }
-                ret_status = sn_coap_parser_options_parse_multiple_options(handle, packet_data_pptr, message_left,
+                packet_data_ptr = sn_coap_parser_options_parse_multiple_options(packet_data_ptr, handle, message_left,
                              &dst_coap_msg_ptr->uri_path_ptr, &dst_coap_msg_ptr->uri_path_len,
                              COAP_OPTION_URI_PATH, option_len);
-                if (ret_status < 0) {
+                if (!packet_data_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_URI_PATH not valid!");
-                    return -1;
+                    return NULL;
                 }
                 break;
 
             case COAP_OPTION_OBSERVE:
                 if ((option_len > 2) || dst_coap_msg_ptr->options_list_ptr->observe != COAP_OBSERVE_NONE) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_OBSERVE not valid!");
-                    return -1;
+                    return NULL;
                 }
-                dst_coap_msg_ptr->options_list_ptr->observe = sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->observe = sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_URI_QUERY:
-                ret_status = sn_coap_parser_options_parse_multiple_options(handle, packet_data_pptr, message_left,
+                packet_data_ptr = sn_coap_parser_options_parse_multiple_options(packet_data_ptr, handle, message_left,
                              &dst_coap_msg_ptr->options_list_ptr->uri_query_ptr, &dst_coap_msg_ptr->options_list_ptr->uri_query_len,
                              COAP_OPTION_URI_QUERY, option_len);
-                if (ret_status < 0) {
+                if (!packet_data_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_URI_QUERY not valid!");
-                    return -1;
+                    return NULL;
                 }
                 break;
 
             case COAP_OPTION_BLOCK2:
                 if ((option_len > 3) || dst_coap_msg_ptr->options_list_ptr->block2 != COAP_OPTION_BLOCK_NONE) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_BLOCK2 not valid!");
-                    return -1;
+                    return NULL;
                 }
-                dst_coap_msg_ptr->options_list_ptr->block2 = sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->block2 = sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_BLOCK1:
                 if ((option_len > 3) || dst_coap_msg_ptr->options_list_ptr->block1 != COAP_OPTION_BLOCK_NONE) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_BLOCK1 not valid!");
-                    return -1;
+                    return NULL;
                 }
-                dst_coap_msg_ptr->options_list_ptr->block1 = sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->block1 = sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_ACCEPT:
                 if ((option_len > 2) || (dst_coap_msg_ptr->options_list_ptr->accept != COAP_CT_NONE)) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_ACCEPT not valid!");
-                    return -1;
+                    return NULL;
                 }
-                dst_coap_msg_ptr->options_list_ptr->accept = (sn_coap_content_format_e) sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->accept = (sn_coap_content_format_e) sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_SIZE1:
                 if ((option_len > 4) || dst_coap_msg_ptr->options_list_ptr->use_size1) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_SIZE1 not valid!");
-                    return -1;
+                    return NULL;
                 }
                 dst_coap_msg_ptr->options_list_ptr->use_size1 = true;
-                dst_coap_msg_ptr->options_list_ptr->size1 = sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->size1 = sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             case COAP_OPTION_SIZE2:
                 if ((option_len > 4) || dst_coap_msg_ptr->options_list_ptr->use_size2) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_SIZE2 not valid!");
-                    return -1;
+                    return NULL;
                 }
                 dst_coap_msg_ptr->options_list_ptr->use_size2 = true;
-                dst_coap_msg_ptr->options_list_ptr->size2 = sn_coap_parser_options_parse_uint(packet_data_pptr, option_len);
+                dst_coap_msg_ptr->options_list_ptr->size2 = sn_coap_parser_options_parse_uint(&packet_data_ptr, option_len);
                 break;
 
             default:
                 tr_error("sn_coap_parser_options_parse - unknown option!");
-                return -1;
+                return NULL;
         }
 
         /* Check for overflow */
-        if ((*packet_data_pptr - packet_data_start_ptr) > packet_len) {
-            return -1;
+        if ((packet_data_ptr - packet_data_start_ptr) > packet_len) {
+            return NULL;
         }
-        message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, packet_data_start_ptr, packet_len, 0);
+        message_left = packet_len - (packet_data_ptr - packet_data_start_ptr);
     }
-    return 0;
+    return packet_data_ptr;
 }
 
 
 /**
- * \fn static int8_t sn_coap_parser_options_parse_multiple_options(uint8_t **packet_data_pptr, uint8_t options_count_left, uint8_t *previous_option_number_ptr, uint8_t **dst_pptr,
+ * \fn static int8_t sn_coap_parser_options_parse_multiple_options(uint8_t *packet_data_pptr, uint8_t options_count_left, uint8_t *previous_option_number_ptr, uint8_t **dst_pptr,
  *                                                                  uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len)
  *
  * \brief Parses CoAP message's Uri-query options
  *
- * \param **packet_data_pptr is source for Packet data to be parsed to CoAP message
+ * \param *packet_data_ptr is source for Packet data to be parsed to CoAP message
  *
  * \param *dst_coap_msg_ptr is destination for parsed CoAP message
  *
@@ -750,26 +753,26 @@ static int8_t sn_coap_parser_options_parse(struct coap_s *handle, uint8_t **pack
  *
  * \param *previous_option_number_ptr is pointer to used and returned previous Option number
  *
- * \return Return value is count of Uri-query optios parsed. In failure case -1 is returned.
+ * \return Return value is advanced input pointer. In failure case NULL is returned.
 */
-static int8_t sn_coap_parser_options_parse_multiple_options(struct coap_s *handle, uint8_t **packet_data_pptr, uint16_t packet_left_len,  uint8_t **dst_pptr, uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len)
+static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t *packet_data_ptr, struct coap_s *handle, uint16_t packet_left_len,  uint8_t **dst_pptr, uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len)
 {
-    int16_t     uri_query_needed_heap       = sn_coap_parser_options_count_needed_memory_multiple_option(*packet_data_pptr, packet_left_len, option, option_number_len);
-    uint8_t    *temp_parsed_uri_query_ptr   = NULL;
-    uint8_t     returned_option_counter     = 0;
-    uint8_t    *start_ptr = *packet_data_pptr;
-    uint16_t    message_left = packet_left_len;
+    int           uri_query_needed_heap       = sn_coap_parser_options_count_needed_memory_multiple_option(packet_data_ptr, packet_left_len, option, option_number_len);
+    uint8_t       *temp_parsed_uri_query_ptr   = NULL;
+    const uint8_t *start_ptr = packet_data_ptr;
+    uint_fast16_t  message_left = packet_left_len;
+    bool           first_option = true;
 
     if (uri_query_needed_heap == -1) {
-        return -1;
+        return NULL;
     }
 
     if (uri_query_needed_heap) {
-        *dst_pptr = (uint8_t *) handle->sn_coap_protocol_malloc(uri_query_needed_heap);
+        *dst_pptr = handle->sn_coap_protocol_malloc(uri_query_needed_heap);
 
         if (*dst_pptr == NULL) {
             tr_error("sn_coap_parser_options_parse_multiple_options - failed to allocate options!");
-            return -1;
+            return NULL;
         }
     }
 
@@ -779,7 +782,7 @@ static int8_t sn_coap_parser_options_parse_multiple_options(struct coap_s *handl
     /* Loop all Uri-Query options */
     while ((temp_parsed_uri_query_ptr - *dst_pptr) < uri_query_needed_heap && message_left) {
         /* Check if this is first Uri-Query option */
-        if (returned_option_counter > 0) {
+        if (!first_option) {
             /* Uri-Query is modified to following format: temp1'\0'temp2'\0'temp3 i.e.  */
             /* Uri-Path is modified to following format: temp1\temp2\temp3 i.e.  */
             if (option == COAP_OPTION_URI_QUERY || option == COAP_OPTION_LOCATION_QUERY || option == COAP_OPTION_ETAG || option == COAP_OPTION_ACCEPT) {
@@ -789,43 +792,42 @@ static int8_t sn_coap_parser_options_parse_multiple_options(struct coap_s *handl
             }
 
             temp_parsed_uri_query_ptr++;
+        } else {
+            first_option = false;
         }
-
-        returned_option_counter++;
 
         if (((temp_parsed_uri_query_ptr - *dst_pptr) + option_number_len) > uri_query_needed_heap) {
-            return -1;
+            return NULL;
         }
-
-        if (0 != sn_coap_parser_check_packet_ptr(*packet_data_pptr, start_ptr, packet_left_len, option_number_len)) {
+        if (0 != sn_coap_parser_check_packet_ptr(packet_data_ptr, start_ptr, packet_left_len, option_number_len)) {
             /* Buffer read overflow. */
-            return -1;
+            return NULL;
         }
 
         /* Copy the option value to URI query buffer */
-        memcpy(temp_parsed_uri_query_ptr, *packet_data_pptr, option_number_len);
+        memcpy(temp_parsed_uri_query_ptr, packet_data_ptr, option_number_len);
 
-        message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, start_ptr, packet_left_len, option_number_len);
+        message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, start_ptr, packet_left_len, option_number_len);
         temp_parsed_uri_query_ptr += option_number_len;
 
         /* Check if there is more input to process */
-        if (message_left == 0 || ((**packet_data_pptr >> COAP_OPTIONS_OPTION_NUMBER_SHIFT) != 0)) {
-            return returned_option_counter;
+        if (message_left == 0 || ((*packet_data_ptr >> COAP_OPTIONS_OPTION_NUMBER_SHIFT) != 0)) {
+            return packet_data_ptr;
         }
 
         /* Process next option */
-        option_number_len = (**packet_data_pptr & 0x0F);
-        message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, start_ptr, packet_left_len, 1);
+        option_number_len = (*packet_data_ptr & 0x0F);
+        message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, start_ptr, packet_left_len, 1);
 
         /* Add possible option length extension to resolve full length of the option */
-        int8_t option_parse_result = parse_ext_option(&option_number_len, packet_data_pptr, start_ptr, packet_left_len, &message_left);
+        int8_t option_parse_result = parse_ext_option(&option_number_len, &packet_data_ptr, start_ptr, packet_left_len, &message_left);
         if (option_parse_result != 0) {
             /* Extended option parsing failed. */
-            return -1;
+            return NULL;
         }
     }
 
-    return returned_option_counter;
+    return packet_data_ptr;
 }
 
 /**
@@ -843,11 +845,11 @@ static int8_t sn_coap_parser_options_parse_multiple_options(struct coap_s *handl
  *
  * \param uint16_t option_number_len length of the first option part
  */
-static int16_t sn_coap_parser_options_count_needed_memory_multiple_option(uint8_t *packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len)
+static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t *packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len)
 {
-    uint16_t ret_value              = 0;
-    uint16_t message_left           = packet_left_len;
-    uint8_t *start_ptr              = packet_data_ptr;
+    int      ret_value              = 0;
+    uint_fast16_t message_left      = packet_left_len;
+    const uint8_t *start_ptr        = packet_data_ptr;
 
     /* Loop all Uri-Query options */
     while (message_left > 0) {
@@ -922,29 +924,29 @@ static int16_t sn_coap_parser_options_count_needed_memory_multiple_option(uint8_
  *
  * \param *dst_coap_msg_ptr is destination for parsed CoAP message
  *****************************************************************************/
-static int8_t sn_coap_parser_payload_parse(uint16_t packet_data_len, uint8_t *packet_data_start_ptr, uint8_t **packet_data_pptr, sn_coap_hdr_s *dst_coap_msg_ptr)
+static const uint8_t *sn_coap_parser_payload_parse(const uint8_t *packet_data_ptr, uint16_t packet_data_len, uint8_t *packet_data_start_ptr, sn_coap_hdr_s *dst_coap_msg_ptr)
 {
     /* If there is payload */
-    if ((*packet_data_pptr - packet_data_start_ptr) < packet_data_len) {
-        if (**packet_data_pptr == 0xff) {
-            (*packet_data_pptr)++;
+    if ((packet_data_ptr - packet_data_start_ptr) < packet_data_len) {
+        if (*packet_data_ptr == 0xff) {
+            packet_data_ptr++;
             /* Parse Payload length */
-            dst_coap_msg_ptr->payload_len = packet_data_len - (*packet_data_pptr - packet_data_start_ptr);
+            dst_coap_msg_ptr->payload_len = packet_data_len - (packet_data_ptr - packet_data_start_ptr);
 
             /* The presence of a marker followed by a zero-length payload MUST be processed as a message format error */
             if (dst_coap_msg_ptr->payload_len == 0) {
-                return -1;
+                return NULL;
             }
 
             /* Parse Payload by setting CoAP message's payload_ptr to point Payload in Packet data */
-            dst_coap_msg_ptr->payload_ptr = *packet_data_pptr;
+            dst_coap_msg_ptr->payload_ptr = (uint8_t *) packet_data_ptr;
         }
         /* No payload marker.. */
         else {
             tr_error("sn_coap_parser_payload_parse - payload marker not found!");
-            return -1;
+            return NULL;
         }
     }
-    return 0;
+    return packet_data_ptr;
 }
 

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -227,7 +227,7 @@ void sn_coap_parser_release_allocated_coap_msg_mem(struct coap_s *handle, sn_coa
  *
  * \param *coap_version_ptr is destination for parsed CoAP specification version
  */
-static const uint8_t *sn_coap_parser_header_parse(const uint8_t *packet_data_ptr, sn_coap_hdr_s *dst_coap_msg_ptr, coap_version_e *coap_version_ptr)
+static const uint8_t *sn_coap_parser_header_parse(const uint8_t * restrict packet_data_ptr, sn_coap_hdr_s * restrict dst_coap_msg_ptr, coap_version_e * restrict coap_version_ptr)
 {
     /* Parse CoAP Version and message type*/
     *coap_version_ptr = (coap_version_e)(*packet_data_ptr & COAP_HEADER_VERSION_MASK);
@@ -251,7 +251,7 @@ static const uint8_t *sn_coap_parser_header_parse(const uint8_t *packet_data_ptr
  *
  * \return Return value is value of uint
  */
-static uint32_t sn_coap_parser_options_parse_uint(const uint8_t **packet_data_pptr, uint8_t option_len)
+static uint32_t sn_coap_parser_options_parse_uint(const uint8_t * restrict * restrict packet_data_pptr, uint8_t option_len)
 {
     uint32_t value = 0;
     const uint8_t *packet_data_ptr = *packet_data_pptr;
@@ -322,7 +322,7 @@ static int8_t sn_coap_parser_check_packet_ptr(const uint8_t *packet_data_ptr, co
  *
  * \return Return The remaining packet data length
  */
-static uint16_t sn_coap_parser_move_packet_ptr(const uint8_t **packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
+static uint16_t sn_coap_parser_move_packet_ptr(const uint8_t * restrict *packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
 {
     const uint8_t *packet_end = packet_data_start_ptr + packet_len;
     const uint8_t *new_data_ptr = *packet_data_pptr + delta;
@@ -405,7 +405,7 @@ static int8_t sn_coap_parser_read_packet_u16(uint16_t *dst, const uint8_t *packe
  *
  * \return Return 0 if the read was successful, -1 otherwise
  */
-static int8_t parse_ext_option(uint16_t *dst, const uint8_t **packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint_fast16_t *message_left)
+static int8_t parse_ext_option(uint16_t *dst, const uint8_t * restrict *packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint_fast16_t *message_left)
 {
     uint16_t option_number = *dst;
 
@@ -457,7 +457,7 @@ static int8_t parse_ext_option(uint16_t *dst, const uint8_t **packet_data_pptr, 
  *
  * \return Return value is advanced input pointer in ok case and NULL in failure case
  */
-static const uint8_t * sn_coap_parser_options_parse(const uint8_t *packet_data_ptr, struct coap_s *handle, sn_coap_hdr_s *dst_coap_msg_ptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len)
+static const uint8_t * sn_coap_parser_options_parse(const uint8_t * restrict packet_data_ptr, struct coap_s * restrict handle, sn_coap_hdr_s * restrict dst_coap_msg_ptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len)
 {
     uint_fast16_t previous_option_number = 0;
     uint_fast16_t message_left           = sn_coap_parser_move_packet_ptr(&packet_data_ptr, packet_data_start_ptr, packet_len, 0);
@@ -755,10 +755,11 @@ static const uint8_t * sn_coap_parser_options_parse(const uint8_t *packet_data_p
  *
  * \return Return value is advanced input pointer. In failure case NULL is returned.
 */
-static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t *packet_data_ptr, struct coap_s *handle, uint16_t packet_left_len,  uint8_t **dst_pptr, uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len)
+static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t * restrict packet_data_ptr, struct coap_s * restrict handle, uint16_t packet_left_len,  uint8_t ** restrict dst_pptr, uint16_t * restrict dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len)
 {
+
     int           uri_query_needed_heap       = sn_coap_parser_options_count_needed_memory_multiple_option(packet_data_ptr, packet_left_len, option, option_number_len);
-    uint8_t       *temp_parsed_uri_query_ptr   = NULL;
+    uint8_t       * restrict temp_parsed_uri_query_ptr   = NULL;
     const uint8_t *start_ptr = packet_data_ptr;
     uint_fast16_t  message_left = packet_left_len;
     bool           first_option = true;
@@ -845,7 +846,7 @@ static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_
  *
  * \param uint16_t option_number_len length of the first option part
  */
-static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t *packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len)
+static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t * restrict packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len)
 {
     int      ret_value              = 0;
     uint_fast16_t message_left      = packet_left_len;
@@ -924,7 +925,7 @@ static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint
  *
  * \param *dst_coap_msg_ptr is destination for parsed CoAP message
  *****************************************************************************/
-static const uint8_t *sn_coap_parser_payload_parse(const uint8_t *packet_data_ptr, uint16_t packet_data_len, uint8_t *packet_data_start_ptr, sn_coap_hdr_s *dst_coap_msg_ptr)
+static const uint8_t *sn_coap_parser_payload_parse(const uint8_t * restrict packet_data_ptr, uint16_t packet_data_len, uint8_t *packet_data_start_ptr, sn_coap_hdr_s * restrict dst_coap_msg_ptr)
 {
     /* If there is payload */
     if ((packet_data_ptr - packet_data_start_ptr) < packet_data_len) {

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -513,7 +513,7 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
 static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *src_coap_msg_ptr, void *param, uint16_t original_payload_len, bool copy_payload)
 {
-    coap_blockwise_msg_s *stored_blockwise_msg_ptr;
+    coap_blockwise_msg_s * restrict stored_blockwise_msg_ptr;
 
     stored_blockwise_msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_blockwise_msg_s));
     if (!stored_blockwise_msg_ptr) {
@@ -525,20 +525,21 @@ static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *
     /* Fill struct */
     stored_blockwise_msg_ptr->timestamp = handle->system_time;
 
-    stored_blockwise_msg_ptr->coap_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
-    if( stored_blockwise_msg_ptr->coap_msg_ptr == NULL ){
+    sn_coap_hdr_s * restrict copied_msg_ptr = sn_coap_protocol_copy_header(handle, src_coap_msg_ptr);
+    if( copied_msg_ptr == NULL ){
         handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
         tr_error("sn_coap_protocol_build - block header copy failed!");
         return -2;
     }
+    stored_blockwise_msg_ptr->coap_msg_ptr = copied_msg_ptr;
 
     if (copy_payload) {
-        stored_blockwise_msg_ptr->coap_msg_ptr->payload_len = original_payload_len;
-        stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr = sn_coap_protocol_malloc_copy(handle, src_coap_msg_ptr->payload_ptr, stored_blockwise_msg_ptr->coap_msg_ptr->payload_len);
+        copied_msg_ptr->payload_len = original_payload_len;
+        copied_msg_ptr->payload_ptr = sn_coap_protocol_malloc_copy(handle, src_coap_msg_ptr->payload_ptr, stored_blockwise_msg_ptr->coap_msg_ptr->payload_len);
 
-        if (!stored_blockwise_msg_ptr->coap_msg_ptr->payload_ptr) {
+        if (!copied_msg_ptr->payload_ptr) {
             //block payload save failed, only first block can be build. Perhaps we should return error.
-            sn_coap_parser_release_allocated_coap_msg_mem(handle, stored_blockwise_msg_ptr->coap_msg_ptr);
+            sn_coap_parser_release_allocated_coap_msg_mem(handle, copied_msg_ptr);
             handle->sn_coap_protocol_free(stored_blockwise_msg_ptr);
             tr_error("sn_coap_protocol_build - block payload allocation failed!");
             return -2;
@@ -546,7 +547,7 @@ static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *
     }
 
     stored_blockwise_msg_ptr->param = param;
-    stored_blockwise_msg_ptr->msg_id = stored_blockwise_msg_ptr->coap_msg_ptr->msg_id;
+    stored_blockwise_msg_ptr->msg_id = copied_msg_ptr->msg_id;
 
     ns_list_add_to_end(&handle->linked_list_blockwise_sent_msgs, stored_blockwise_msg_ptr);
 
@@ -554,9 +555,8 @@ static int16_t store_blockwise_copy(struct coap_s *handle, const sn_coap_hdr_s *
 }
 #endif
 
-sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t packet_data_len, uint8_t *packet_data_ptr, void *param)
+sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict src_addr_ptr, uint16_t packet_data_len, uint8_t * restrict packet_data_ptr, void *param)
 {
-    sn_coap_hdr_s   *returned_dst_coap_msg_ptr = NULL;
     coap_version_e   coap_version              = COAP_VERSION_UNKNOWN;
 
     /* * * * Check given pointer * * * */
@@ -566,7 +566,7 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
     }
 
     /* * * * Parse Packet data to CoAP message by using CoAP Header parser * * * */
-    returned_dst_coap_msg_ptr = sn_coap_parser(handle, packet_data_len, packet_data_ptr, &coap_version);
+    sn_coap_hdr_s * restrict returned_dst_coap_msg_ptr = sn_coap_parser(handle, packet_data_len, packet_data_ptr, &coap_version);
 
     /* Check status of returned pointer */
     if (returned_dst_coap_msg_ptr == NULL) {
@@ -928,11 +928,11 @@ rescan:
  * \return 1 Msg stored properly
  *****************************************************************************/
 
-static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t send_packet_data_len,
-        uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param)
+static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict dst_addr_ptr, uint16_t send_packet_data_len,
+        uint8_t * restrict send_packet_data_ptr, uint32_t sending_time, void *param)
 {
 
-    coap_send_msg_s *stored_msg_ptr;
+    coap_send_msg_s * restrict stored_msg_ptr;
 
     /* If both queue parameters are "0" or resending count is "0", then re-sending is disabled */
     if (((handle->sn_coap_resending_queue_msgs == 0) && (handle->sn_coap_resending_queue_bytes == 0)) || (handle->sn_coap_resending_count == 0)) {
@@ -995,7 +995,7 @@ static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle
  * \param msg_id is searching key for removed message
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id)
+static void sn_coap_protocol_linked_list_send_msg_remove(struct coap_s * restrict handle, const sn_nsdl_addr_s * restrict src_addr_ptr, uint16_t msg_id)
 {
     /* Loop all stored resending messages in Linked list */
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, &handle->linked_list_resent_msgs) {
@@ -1065,10 +1065,10 @@ uint16_t sn_coap_protocol_get_configured_blockwise_size(struct coap_s *handle)
  * \param *addr_ptr is pointer to Address information to be stored
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *handle, sn_nsdl_addr_s *addr_ptr,
+static void sn_coap_protocol_linked_list_duplication_info_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict addr_ptr,
         uint16_t msg_id, void *param)
 {
-    coap_duplication_info_s *stored_duplication_info_ptr = NULL;
+    coap_duplication_info_s * restrict stored_duplication_info_ptr = NULL;
 
     /* * * * Allocating memory for stored Duplication info * * * */
 
@@ -1247,10 +1247,10 @@ static void sn_coap_protocol_linked_list_blockwise_msg_remove(struct coap_s *han
  * \param size1 Size of the whole incoming message
  *****************************************************************************/
 
-static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *handle, sn_nsdl_addr_s *addr_ptr,
+static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict addr_ptr,
         uint16_t payload_len,
-        uint8_t *payload_ptr,
-        uint8_t *token_ptr,
+        uint8_t * restrict payload_ptr,
+        uint8_t * restrict token_ptr,
         uint8_t token_len,
         uint32_t block_number,
         uint16_t block_size,
@@ -1269,7 +1269,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
         return;
     }
 
-    coap_blockwise_payload_s *stored_blockwise_payload_ptr = sn_coap_protocol_linked_list_blockwise_search(handle, addr_ptr, token_ptr, token_len);
+    coap_blockwise_payload_s * restrict stored_blockwise_payload_ptr = sn_coap_protocol_linked_list_blockwise_search(handle, addr_ptr, token_ptr, token_len);
 
     if (stored_blockwise_payload_ptr && stored_blockwise_payload_ptr->use_size1) {
         memcpy(stored_blockwise_payload_ptr->payload_ptr + (block_number * block_size), payload_ptr, payload_len);
@@ -1277,7 +1277,7 @@ static void sn_coap_protocol_linked_list_blockwise_payload_store(struct coap_s *
         uint16_t new_len = stored_blockwise_payload_ptr->payload_len + payload_len;
         tr_debug("sn_coap_protocol_linked_list_blockwise_payload_store - reallocate from %d to %d", stored_blockwise_payload_ptr->payload_len, new_len);
 
-        uint8_t *temp_ptr = handle->sn_coap_protocol_malloc(stored_blockwise_payload_ptr->payload_len);
+        uint8_t * restrict temp_ptr = handle->sn_coap_protocol_malloc(stored_blockwise_payload_ptr->payload_len);
         if (temp_ptr == NULL) {
             tr_error("sn_coap_protocol_linked_list_blockwise_payload_store - failed to allocate temp buffer!");
             sn_coap_protocol_linked_list_blockwise_payload_remove(handle, stored_blockwise_payload_ptr);
@@ -1748,7 +1748,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 {
     sn_coap_hdr_s *src_coap_blockwise_ack_msg_ptr = NULL;
     uint16_t dst_packed_data_needed_mem = 0;
-    uint8_t *dst_ack_packet_data_ptr = NULL;
+    uint8_t * restrict dst_ack_packet_data_ptr = NULL;
     uint8_t block_temp = 0;
 
     uint16_t original_payload_len = 0;
@@ -1919,7 +1919,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                     }
 
                     if (block_temp > sn_coap_convert_block_size(handle->sn_coap_block_data_size)) {
-                        src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1 &= 0xFFFFF8;
+                        src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1 &= 0xFFFFFFF8;
                         src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1 |= sn_coap_convert_block_size(handle->sn_coap_block_data_size);
                     }
                 }
@@ -2316,9 +2316,9 @@ int8_t sn_coap_convert_block_size(uint16_t block_size)
     return -1;
 }
 
-static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, const sn_coap_hdr_s *source_header_ptr)
+static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s * restrict handle, const sn_coap_hdr_s * restrict source_header_ptr)
 {
-    sn_coap_hdr_s *destination_header_ptr;
+    sn_coap_hdr_s * restrict destination_header_ptr;
 
     destination_header_ptr = sn_coap_parser_alloc_message(handle);
     if (!destination_header_ptr) {
@@ -2361,8 +2361,8 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, const 
             return 0;
         }
 
-        const sn_coap_options_list_s *source_options_list_ptr = source_header_ptr->options_list_ptr;
-        sn_coap_options_list_s *destination_options_list_ptr = destination_header_ptr->options_list_ptr;
+        const sn_coap_options_list_s * restrict source_options_list_ptr = source_header_ptr->options_list_ptr;
+        sn_coap_options_list_s * restrict destination_options_list_ptr = destination_header_ptr->options_list_ptr;
 
         destination_options_list_ptr->max_age = source_options_list_ptr->max_age;
 

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -78,7 +78,7 @@ static uint8_t               sn_coap_protocol_linked_list_send_msg_store(struct 
 static void                  sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
 static coap_send_msg_s      *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t packet_data_len);
 static void                  sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr);
-static uint16_t              sn_coap_count_linked_list_size(const coap_send_msg_list_t *linked_list_ptr);
+static uint_fast16_t         sn_coap_count_linked_list_size(const coap_send_msg_list_t *linked_list_ptr);
 static uint32_t              sn_coap_calculate_new_resend_time(const uint32_t current_time, const uint8_t interval, const uint8_t counter);
 #endif
 
@@ -202,19 +202,9 @@ int8_t sn_coap_protocol_set_block_size(struct coap_s *handle, uint16_t block_siz
     if (handle == NULL) {
         return -1;
     }
-    switch (block_size) {
-        case 0:
-        case 16:
-        case 32:
-        case 64:
-        case 128:
-        case 256:
-        case 512:
-        case 1024:
-            handle->sn_coap_block_data_size = block_size;
-            return 0;
-        default:
-            break;
+    if (sn_coap_convert_block_size(block_size) >= 0) {
+        handle->sn_coap_block_data_size = block_size;
+        return 0;
     }
 #endif
     return -1;
@@ -317,8 +307,8 @@ void sn_coap_protocol_clear_retransmission_buffer(struct coap_s *handle)
     ns_list_foreach_safe(coap_send_msg_s, tmp, &handle->linked_list_resent_msgs) {
         ns_list_remove(&handle->linked_list_resent_msgs, tmp);
         sn_coap_protocol_release_allocated_send_msg_mem(handle, tmp);
-        --handle->count_resent_msgs;
     }
+    handle->count_resent_msgs = 0;
 #endif
 }
 
@@ -1209,14 +1199,14 @@ void sn_coap_protocol_linked_list_duplication_info_remove(struct coap_s *handle,
 #if SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 static void sn_coap_protocol_duplication_info_free(struct coap_s *handle, coap_duplication_info_s *duplication_info_ptr)
 {
-    if (duplication_info_ptr) {
-        if (duplication_info_ptr->address) {
-            handle->sn_coap_protocol_free(duplication_info_ptr->address->addr_ptr);
-            handle->sn_coap_protocol_free(duplication_info_ptr->address);
-        }
-        handle->sn_coap_protocol_free(duplication_info_ptr->packet_ptr);
-        handle->sn_coap_protocol_free(duplication_info_ptr);
+    // General purpose free functions ignore null pointer inputs - this
+    // private one knows it never receives null.
+    if (duplication_info_ptr->address) {
+        handle->sn_coap_protocol_free(duplication_info_ptr->address->addr_ptr);
+        handle->sn_coap_protocol_free(duplication_info_ptr->address);
     }
+    handle->sn_coap_protocol_free(duplication_info_ptr->packet_ptr);
+    handle->sn_coap_protocol_free(duplication_info_ptr);
 }
 #endif // SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 
@@ -1650,9 +1640,9 @@ static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handl
  *
  * \param const coap_send_msg_list_t *linked_list_ptr pointer to linked list
  *****************************************************************************/
-static uint16_t sn_coap_count_linked_list_size(const coap_send_msg_list_t *linked_list_ptr)
+static uint_fast16_t sn_coap_count_linked_list_size(const coap_send_msg_list_t *linked_list_ptr)
 {
-    uint16_t total_size = 0;
+    uint_fast16_t total_size = 0;
 
     ns_list_foreach(coap_send_msg_s, stored_msg_ptr, linked_list_ptr) {
         total_size += stored_msg_ptr->send_msg_ptr.packet_len;
@@ -1777,13 +1767,13 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 if (stored_blockwise_msg_temp_ptr) {
                     /* Build response message */
 
-                    uint16_t block_size;
+                    uint_fast16_t block_size;
                     uint32_t block_number;
 
                     /* Get block option parameters from received message */
                     block_number = received_coap_msg_ptr->options_list_ptr->block1 >> 4;
                     block_temp = received_coap_msg_ptr->options_list_ptr->block1 & 0x07;
-                    block_size = 1u << (block_temp + 4);
+                    block_size = 16u << block_temp;
 
                     /* Build next block message */
                     src_coap_blockwise_ack_msg_ptr = stored_blockwise_msg_temp_ptr->coap_msg_ptr;
@@ -1919,7 +1909,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
 
                     /* Check block size */
                     block_temp = (src_coap_blockwise_ack_msg_ptr->options_list_ptr->block1 & 0x07);
-                    uint16_t block_size = 1u << (block_temp + 4);
+                    uint_fast16_t block_size = 16u << block_temp;
 
                     if (block_size >  handle->sn_coap_block_data_size) {
                          // Include maximum size that stack can handle into response
@@ -2175,7 +2165,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 block_temp = received_coap_msg_ptr->options_list_ptr->block2 & 0x07;
 
                 /* Resolve block parameters */
-                const uint16_t block_size = 1u << (block_temp + 4);
+                const uint_fast16_t block_size = 16u << block_temp;
                 const uint32_t block_number = received_coap_msg_ptr->options_list_ptr->block2 >> 4;
 
 
@@ -2318,23 +2308,12 @@ static bool sn_coap_handle_last_blockwise(struct coap_s *handle, const sn_nsdl_a
 
 int8_t sn_coap_convert_block_size(uint16_t block_size)
 {
-    if (block_size == 16) {
-        return 0;
-    } else if (block_size == 32) {
-        return 1;
-    } else if (block_size == 64) {
-        return 2;
-    } else if (block_size == 128) {
-        return 3;
-    } else if (block_size == 256) {
-        return 4;
-    } else if (block_size == 512) {
-        return 5;
-    } else if (block_size == 1024) {
-        return 6;
-    } else {
-       return 0;
+    for (int n = 0; n < 6; n++) {
+        if (block_size == (16 << n)) {
+            return n;
+        }
     }
+    return -1;
 }
 
 static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s *handle, const sn_coap_hdr_s *source_header_ptr)


### PR DESCRIPTION
<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[X] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[] I confirm the moderators may change the PR before merging it in.

### Summary of changes <!-- Required -->

Simplify packet builder and parser, primarily by eliminating double pointer indirection. Use return values to help with that.

No public API changes - all changes are internal.

Saves around 300 bytes of code size.
