### PR TITLE
Update CHANGELOG to v.5.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v5.1.7](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.7)
+
+- Removed comparison of IP addresses when validating message resending. This avoids unnessary network errors due to load balancers causing frequent IP address changes.
+
 ## [v5.1.6](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.6)
 
 - Multiple fixes for out-ouf-bounds memory accesses, a memory leak and an infinite loop condition in packet parser.


### PR DESCRIPTION
## [v5.1.7](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.7)

- Removed comparison of IP addresses when validating message resending. This avoids unnessary network errors due to load balancers causing frequent IP address changes.