### PR TITLE
Update CHANGELOG to v5.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## [v5.1.8](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.8)
+
 - Fix to blockwise code. Now uses block size received in packet, not block size defined in code.
 
 ## [v5.1.7](https://github.com/ARMmbed/mbed-coap/releases/tag/v5.1.7)


### PR DESCRIPTION
<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

- Fix to blockwise code. Now uses block size received in packet, not block size defined in code.


