### PR TITLE
Minor code size optimisations

### DIFF
--- a/source/include/sn_coap_header_internal.h
+++ b/source/include/sn_coap_header_internal.h
@@ -58,12 +58,12 @@ extern "C" {
  * \brief This structure is returned by sn_coap_exec() for sending
  */
 typedef struct sn_nsdl_transmit_ {
+    uint8_t                *packet_ptr;
+    uint16_t                packet_len;
     sn_nsdl_addr_s          dst_addr_ptr;
 
     sn_nsdl_capab_e         protocol;
 
-    uint16_t                packet_len;
-    uint8_t                *packet_ptr;
 } sn_nsdl_transmit_s;
 
 /* * * * * * * * * * * * * * * * * * * * * * */

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -45,7 +45,7 @@ int8_t prepare_blockwise_message(struct coap_s *handle, struct sn_coap_hdr_ *coa
 
 /* Structure which is stored to Linked list for message sending purposes */
 typedef struct coap_send_msg_ {
-    uint8_t             resending_counter;  /* Tells how many times message is still tried to resend */
+    uint_fast8_t        resending_counter;  /* Tells how many times message is still tried to resend */
     uint32_t            resending_time;     /* Tells next resending time */
 
     sn_nsdl_transmit_s  send_msg_ptr;
@@ -137,10 +137,10 @@ struct coap_s {
 };
 
 /* Utility function which performs a call to sn_coap_protocol_malloc() and memset's the result to zero. */
-void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length);
+void *sn_coap_protocol_calloc(struct coap_s *handle, uint_fast16_t length);
 
 /* Utility function which performs a call to sn_coap_protocol_malloc() and memcopy's the source to result buffer. */
-void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint16_t length);
+void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint_fast16_t length);
 
 #ifdef __cplusplus
 }

--- a/source/include/sn_coap_protocol_internal.h
+++ b/source/include/sn_coap_protocol_internal.h
@@ -86,25 +86,35 @@ typedef NS_LIST_HEAD(coap_blockwise_msg_s, link) coap_blockwise_msg_list_t;
 
 /* Structure which is stored to Linked list for blockwise messages receiving purposes */
 typedef struct coap_blockwise_payload_ {
-    uint32_t            timestamp; /* Tells when Payload is stored to Linked list */
-
     uint8_t             addr_len;
-    uint8_t             *addr_ptr;
+    uint8_t             token_len;
+    bool                use_size1;
     uint16_t            port;
+    uint16_t            payload_len;
+    uint8_t             *addr_ptr;
     uint32_t            block_number;
     uint8_t             *token_ptr;
-    uint8_t             token_len;
-
-    uint16_t            payload_len;
     uint8_t             *payload_ptr;
-    bool                use_size1;
-
+    uint32_t            timestamp; /* Tells when Payload is stored to Linked list */
     ns_list_link_t     link;
 } coap_blockwise_payload_s;
 
 typedef NS_LIST_HEAD(coap_blockwise_payload_s, link) coap_blockwise_payload_list_t;
 
 struct coap_s {
+    uint8_t sn_coap_resending_queue_msgs;
+    uint8_t sn_coap_resending_count;
+    uint8_t sn_coap_resending_intervall;
+    uint8_t sn_coap_duplication_buffer_size;
+    uint8_t sn_coap_internal_block2_resp_handling; /* If this is set then coap itself sends a next GET request automatically */
+    uint16_t sn_coap_block_data_size;
+    #if ENABLE_RESENDINGS
+    uint16_t count_resent_msgs;
+    #endif
+#if SN_COAP_DUPLICATION_MAX_MSGS_COUNT
+    uint16_t                      count_duplication_msgs;
+#endif
+
     void *(*sn_coap_protocol_malloc)(uint16_t);
     void (*sn_coap_protocol_free)(void *);
 
@@ -113,12 +123,10 @@ struct coap_s {
 
     #if ENABLE_RESENDINGS /* If Message resending is not used at all, this part of code will not be compiled */
         coap_send_msg_list_t linked_list_resent_msgs; /* Active resending messages are stored to this Linked list */
-        uint16_t count_resent_msgs;
     #endif
 
     #if SN_COAP_DUPLICATION_MAX_MSGS_COUNT /* If Message duplication detection is not used at all, this part of code will not be compiled */
         coap_duplication_info_list_t  linked_list_duplication_msgs; /* Messages for duplicated messages detection is stored to this Linked list */
-        uint16_t                      count_duplication_msgs;
     #endif
 
     #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwise is not enabled, this part of code will not be compiled */
@@ -127,13 +135,7 @@ struct coap_s {
     #endif
 
     uint32_t system_time;    /* System time seconds */
-    uint16_t sn_coap_block_data_size;
-    uint8_t sn_coap_resending_queue_msgs;
     uint32_t sn_coap_resending_queue_bytes;
-    uint8_t sn_coap_resending_count;
-    uint8_t sn_coap_resending_intervall;
-    uint8_t sn_coap_duplication_buffer_size;
-    uint8_t sn_coap_internal_block2_resp_handling; /* If this is set then coap itself sends a next GET request automatically */
 };
 
 /* Utility function which performs a call to sn_coap_protocol_malloc() and memset's the result to zero. */

--- a/source/sn_coap_builder.c
+++ b/source/sn_coap_builder.c
@@ -39,14 +39,14 @@
 /* * * * LOCAL FUNCTION PROTOTYPES * * * */
 static uint8_t *sn_coap_builder_header_build(uint8_t *dst_packet_data_pptr, const sn_coap_hdr_s *src_coap_msg_ptr);
 static uint8_t *sn_coap_builder_options_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr);
-static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
-static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t *dst_packet_data_ptr, uint16_t option_len, const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
-static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t *dst_packet_data_pptr, const uint8_t *src_pptr, uint16_t src_len_ptr, sn_coap_option_numbers_e option, uint16_t *previous_option_number);
+static uint_fast16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
+static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t *dst_packet_data_ptr, uint_fast16_t option_len, const uint8_t *option_ptr, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
+static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t *dst_packet_data_pptr, const uint8_t *src_pptr, uint_fast16_t src_len, sn_coap_option_numbers_e option, uint16_t *previous_option_number);
 static uint_fast8_t sn_coap_builder_options_calc_uint_option_size(uint32_t option_value);
 static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t *dst_packet_data_ptr, uint32_t value, sn_coap_option_numbers_e option_number, uint16_t *previous_option_number);
-static uint8_t  sn_coap_builder_options_get_option_part_count(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
-static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, const uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
-static int_fast16_t sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr, uint8_t query_index, sn_coap_option_numbers_e option);
+static uint_fast8_t  sn_coap_builder_options_get_option_part_count(uint_fast16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option);
+static uint_fast16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint_fast16_t query_len, const uint8_t *query_ptr, uint_fast8_t query_index, sn_coap_option_numbers_e option);
+static int_fast16_t sn_coap_builder_options_get_option_part_position(uint_fast16_t query_len, const uint8_t *query_ptr, uint_fast8_t query_index, sn_coap_option_numbers_e option);
 static uint8_t *sn_coap_builder_payload_build(uint8_t *dst_packet_data_ptr, const sn_coap_hdr_s *src_coap_msg_ptr);
 static uint_fast8_t sn_coap_builder_options_calculate_jump_need(const sn_coap_hdr_s *src_coap_msg_ptr);
 
@@ -678,7 +678,7 @@ static uint8_t *sn_coap_builder_options_build(uint8_t * restrict dst_packet_data
  *
  * \return Advanced destination
  */
-static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t * restrict dst_packet_data_ptr, uint16_t option_len,
+static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t * restrict dst_packet_data_ptr, uint_fast16_t option_len,
         const uint8_t * restrict option_ptr, sn_coap_option_numbers_e option_number, uint16_t * restrict previous_option_number)
 {
     /* Check if there is option at all */
@@ -689,7 +689,7 @@ static uint8_t *sn_coap_builder_options_build_add_one_option(uint8_t * restrict 
 
         /* * * Build option header * * */
 
-        uint8_t first_byte;
+        uint_fast8_t first_byte;
 
         /* First option length without extended part */
         if (option_len <= 12) {
@@ -779,7 +779,7 @@ static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t * restrict
     uint8_t payload[4];
     uint_fast8_t len = 0;
     /* Construct the variable-length payload representing the value */
-    for (uint8_t i = 0; i < 4; i++) {
+    for (uint_fast8_t i = 0; i < 4; i++) {
         if (len > 0 || (option_value & 0xff000000)) {
             payload[len++] = option_value >> 24;
         }
@@ -804,14 +804,14 @@ static uint8_t *sn_coap_builder_options_build_add_uint_option(uint8_t * restrict
  *
  * \return Returns updated output pointer
  */
-static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t * restrict dst_packet_data_ptr, const uint8_t * restrict src_pptr, uint16_t src_len, sn_coap_option_numbers_e option, uint16_t * restrict previous_option_number)
+static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t * restrict dst_packet_data_ptr, const uint8_t * restrict src_pptr, uint_fast16_t src_len, sn_coap_option_numbers_e option, uint16_t * restrict previous_option_number)
 {
     /* Check if there is option at all */
     if (src_pptr != NULL) {
         const uint8_t * restrict query_ptr  = src_pptr;
-        uint8_t     query_part_count        = 0;
-        uint16_t    query_len               = src_len;
-        uint8_t     i                       = 0;
+        uint_fast8_t query_part_count       = 0;
+        uint_fast16_t query_len             = src_len;
+        uint_fast8_t i                      = 0;
         uint_fast16_t query_part_offset     = 0;
 
         /* Get query part count */
@@ -820,7 +820,7 @@ static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t * rest
         /* * * * Options by adding all parts to option * * * */
         for (i = 0; i < query_part_count; i++) {
             /* Get length of query part */
-            uint16_t one_query_part_len = sn_coap_builder_options_get_option_part_length_from_whole_option_string(query_len, query_ptr, i, option);
+            uint_fast16_t one_query_part_len = sn_coap_builder_options_get_option_part_length_from_whole_option_string(query_len, query_ptr, i, option);
 
             /* Get position of query part */
             query_part_offset = sn_coap_builder_options_get_option_part_position(query_len, query_ptr, i, option);
@@ -845,9 +845,9 @@ static uint8_t *sn_coap_builder_options_build_add_multiple_option(uint8_t * rest
  *
  * \return Return value is count of needed memory as bytes for Uri-query option
  */
-static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
+static uint_fast16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
 {
-    uint8_t       query_part_count  = sn_coap_builder_options_get_option_part_count(query_len, query_ptr, option);
+    uint_fast8_t  query_part_count  = sn_coap_builder_options_get_option_part_count(query_len, query_ptr, option);
     uint_fast8_t  i                 = 0;
     uint_fast16_t ret_value         = 0;
 
@@ -858,7 +858,7 @@ static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, con
         /* * * Length of Option number and Option value length * * */
 
         /* Get length of Query part */
-        uint16_t one_query_part_len = sn_coap_builder_options_get_option_part_length_from_whole_option_string(query_len, query_ptr, i, option);
+        uint_fast16_t one_query_part_len = sn_coap_builder_options_get_option_part_length_from_whole_option_string(query_len, query_ptr, i, option);
 
         /* Check option length */
         switch (option) {
@@ -926,7 +926,7 @@ static uint16_t sn_coap_builder_options_calc_option_size(uint16_t query_len, con
  *
  * \return Return value is count of query parts
  */
-static uint8_t sn_coap_builder_options_get_option_part_count(uint16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
+static uint_fast8_t sn_coap_builder_options_get_option_part_count(uint_fast16_t query_len, const uint8_t *query_ptr, sn_coap_option_numbers_e option)
 {
     if (query_len <= 2) {
         return 1;
@@ -968,8 +968,8 @@ static uint8_t sn_coap_builder_options_get_option_part_count(uint16_t query_len,
  *
  * \return Return value is length of query part
  */
-static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint16_t query_len, const uint8_t *query_ptr,
-        uint8_t query_index, sn_coap_option_numbers_e option)
+static uint_fast16_t sn_coap_builder_options_get_option_part_length_from_whole_option_string(uint_fast16_t query_len, const uint8_t *query_ptr,
+        uint_fast8_t query_index, sn_coap_option_numbers_e option)
 {
     uint_fast16_t returned_query_part_len = 0;
     uint_fast8_t  temp_query_index        = 0;
@@ -1026,8 +1026,8 @@ static uint16_t sn_coap_builder_options_get_option_part_length_from_whole_option
  * \return Return value is position (= offset) of query part in whole query. In
  *         fail cases -1 is returned.
  */
-static int_fast16_t sn_coap_builder_options_get_option_part_position(uint16_t query_len, const uint8_t *query_ptr,
-        uint8_t query_index, sn_coap_option_numbers_e option)
+static int_fast16_t sn_coap_builder_options_get_option_part_position(uint_fast16_t query_len, const uint8_t *query_ptr,
+        uint_fast8_t query_index, sn_coap_option_numbers_e option)
 {
     uint_fast16_t returned_query_part_offset = 0;
     uint_fast8_t  temp_query_index           = 0;

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -587,15 +587,17 @@ static const uint8_t * sn_coap_parser_options_parse(const uint8_t * restrict pac
                     return NULL;
                 }
                 /* This is managed independently because User gives this option in one character table */
+                uint16_t len;
                 packet_data_ptr = sn_coap_parser_options_parse_multiple_options(packet_data_ptr, handle,
                              message_left,
                              &dst_coap_msg_ptr->options_list_ptr->etag_ptr,
-                             (uint16_t *)&dst_coap_msg_ptr->options_list_ptr->etag_len,
+                             &len,
                              COAP_OPTION_ETAG, option_len);
                 if (!packet_data_ptr) {
                     tr_error("sn_coap_parser_options_parse - COAP_OPTION_ETAG not valid!");
                     return NULL;
                 }
+                dst_coap_msg_ptr->options_list_ptr->etag_len = (uint8_t) len;
                 break;
 
             case COAP_OPTION_URI_HOST:

--- a/source/sn_coap_parser.c
+++ b/source/sn_coap_parser.c
@@ -44,8 +44,8 @@
 
 static const uint8_t *sn_coap_parser_header_parse(const uint8_t *packet_data_ptr, sn_coap_hdr_s *dst_coap_msg_ptr, coap_version_e *coap_version_ptr);
 static const uint8_t *sn_coap_parser_options_parse(const uint8_t *packet_data_ptr, struct coap_s *handle, sn_coap_hdr_s *dst_coap_msg_ptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len);
-static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t *packet_data_ptr, struct coap_s *handle, uint16_t packet_left_len,  uint8_t **dst_pptr, uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len);
-static int            sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t *packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len);
+static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t *packet_data_ptr, struct coap_s *handle, uint_fast16_t packet_left_len,  uint8_t **dst_pptr, uint16_t *dst_len_ptr, sn_coap_option_numbers_e option, uint_fast16_t option_number_len);
+static int            sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t *packet_data_ptr, uint_fast16_t packet_left_len, sn_coap_option_numbers_e option, uint_fast16_t option_number_len);
 static const uint8_t *sn_coap_parser_payload_parse(const uint8_t *packet_data_ptr, uint16_t packet_data_len, uint8_t *packet_data_start_ptr, sn_coap_hdr_s *dst_coap_msg_ptr);
 
 sn_coap_hdr_s *sn_coap_parser_init_message(sn_coap_hdr_s *coap_msg_ptr)
@@ -251,7 +251,7 @@ static const uint8_t *sn_coap_parser_header_parse(const uint8_t * restrict packe
  *
  * \return Return value is value of uint
  */
-static uint32_t sn_coap_parser_options_parse_uint(const uint8_t * restrict * restrict packet_data_pptr, uint8_t option_len)
+static uint32_t sn_coap_parser_options_parse_uint(const uint8_t * restrict * restrict packet_data_pptr, uint_fast8_t option_len)
 {
     uint32_t value = 0;
     const uint8_t *packet_data_ptr = *packet_data_pptr;
@@ -270,15 +270,15 @@ static uint32_t sn_coap_parser_options_parse_uint(const uint8_t * restrict * res
  * \param b            second term of addion
  * \param result       pointer to the result variable
  *
- * \return Return 0 if there was no overflow, -1 otherwise
+ * \return Return 0 if there was no overflow, non-zero otherwise
  */
-static int8_t sn_coap_parser_add_u16_limit(uint16_t a, uint16_t b, uint16_t *result)
+static int_fast8_t sn_coap_parser_add_u16_limit(uint_fast16_t a, uint_fast16_t b, uint_fast16_t *result)
 {
     uint16_t c;
 
     c = a + b;
     if (c < a || c < b) {
-        return -1;
+        return 1;
     }
 
     *result = c;
@@ -294,19 +294,19 @@ static int8_t sn_coap_parser_add_u16_limit(uint16_t a, uint16_t b, uint16_t *res
  * \param packet_len                total packet length
  * \param delta                     the number of bytes forward to check
  *
- * \return Return 0 if the data is within the bounds, -1 otherwise
+ * \return Return 0 if the data is within the bounds, non-zero otherwise
  */
-static int8_t sn_coap_parser_check_packet_ptr(const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
+static int_fast8_t sn_coap_parser_check_packet_ptr(const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len, uint_fast16_t delta)
 {
     const uint8_t *packet_end = packet_data_start_ptr + packet_len;
     const uint8_t *new_data_ptr = packet_data_ptr + delta;
 
     if (delta > packet_len) {
-        return -1;
+        return 1;
     }
 
     if (new_data_ptr < packet_data_start_ptr || new_data_ptr > packet_end) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -322,7 +322,7 @@ static int8_t sn_coap_parser_check_packet_ptr(const uint8_t *packet_data_ptr, co
  *
  * \return Return The remaining packet data length
  */
-static uint16_t sn_coap_parser_move_packet_ptr(const uint8_t * restrict *packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint16_t delta)
+static uint_fast16_t sn_coap_parser_move_packet_ptr(const uint8_t * restrict *packet_data_pptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len, uint_fast16_t delta)
 {
     const uint8_t *packet_end = packet_data_start_ptr + packet_len;
     const uint8_t *new_data_ptr = *packet_data_pptr + delta;
@@ -336,7 +336,7 @@ static uint16_t sn_coap_parser_move_packet_ptr(const uint8_t * restrict *packet_
 
     *packet_data_pptr = new_data_ptr;
 
-    return (uint16_t)(packet_end - new_data_ptr);
+    return (uint_fast16_t)(packet_end - new_data_ptr);
 }
 
 /**
@@ -347,11 +347,11 @@ static uint16_t sn_coap_parser_move_packet_ptr(const uint8_t * restrict *packet_
  * \param packet_data_start_ptr     pointer to data packet start
  * \param packet_len                total packet length
  *
- * \return Return 0 if the data is within the bounds, -1 otherwise
+ * \return Return 0 if the data is within the bounds, non-zero otherwise
  */
-static int8_t sn_coap_parser_read_packet_u8(uint8_t *dst, const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len)
+static int8_t sn_coap_parser_read_packet_u8(uint8_t *dst, const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len)
 {
-    int8_t ptr_check_result;
+    int_fast8_t ptr_check_result;
 
     ptr_check_result = sn_coap_parser_check_packet_ptr(packet_data_ptr, packet_data_start_ptr, packet_len, 1);
 
@@ -374,12 +374,12 @@ static int8_t sn_coap_parser_read_packet_u8(uint8_t *dst, const uint8_t *packet_
  * \param packet_data_start_ptr     pointer to data packet start
  * \param packet_len                total packet length
  *
- * \return Return 0 if the data is within the bounds, -1 otherwise
+ * \return Return 0 if the data is within the bounds, non-zero otherwise
  */
-static int8_t sn_coap_parser_read_packet_u16(uint16_t *dst, const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len)
+static int_fast8_t sn_coap_parser_read_packet_u16(uint_fast16_t *dst, const uint8_t *packet_data_ptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len)
 {
-    int8_t ptr_check_result;
-    uint16_t value;
+    int_fast8_t ptr_check_result;
+    uint_fast16_t value;
 
     ptr_check_result = sn_coap_parser_check_packet_ptr(packet_data_ptr, packet_data_start_ptr, packet_len, 2);
 
@@ -405,9 +405,9 @@ static int8_t sn_coap_parser_read_packet_u16(uint16_t *dst, const uint8_t *packe
  *
  * \return Return 0 if the read was successful, -1 otherwise
  */
-static int8_t parse_ext_option(uint16_t *dst, const uint8_t * restrict *packet_data_pptr, const uint8_t *packet_data_start_ptr, uint16_t packet_len, uint_fast16_t *message_left)
+static int_fast8_t parse_ext_option(uint_fast16_t *dst, const uint8_t * restrict *packet_data_pptr, const uint8_t *packet_data_start_ptr, uint_fast16_t packet_len, uint_fast16_t *message_left)
 {
-    uint16_t option_number = *dst;
+    uint_fast16_t option_number = *dst;
 
     if (option_number == 13) {
         uint8_t option_ext;
@@ -424,7 +424,7 @@ static int8_t parse_ext_option(uint16_t *dst, const uint8_t * restrict *packet_d
             *message_left = sn_coap_parser_move_packet_ptr(packet_data_pptr, packet_data_start_ptr, packet_len, 1);
         }
     } else if (option_number == 14) {
-        int8_t read_result = sn_coap_parser_read_packet_u16(&option_number, *packet_data_pptr, packet_data_start_ptr, packet_len);
+        int_fast8_t read_result = sn_coap_parser_read_packet_u16(&option_number, *packet_data_pptr, packet_data_start_ptr, packet_len);
         if (read_result != 0) {
             /* packet_data_pptr would overflow! */
             tr_error("sn_coap_parser_options_parse - **packet_data_pptr overflow !");
@@ -466,7 +466,7 @@ static const uint8_t * sn_coap_parser_options_parse(const uint8_t * restrict pac
     dst_coap_msg_ptr->token_len = *packet_data_start_ptr & COAP_HEADER_TOKEN_LENGTH_MASK;
 
     if (dst_coap_msg_ptr->token_len) {
-        int8_t ptr_check_result;
+        int_fast8_t ptr_check_result;
         if ((dst_coap_msg_ptr->token_len > 8) || dst_coap_msg_ptr->token_ptr) {
             tr_error("sn_coap_parser_options_parse - token not valid!");
             return NULL;
@@ -491,14 +491,15 @@ static const uint8_t * sn_coap_parser_options_parse(const uint8_t * restrict pac
     message_left = packet_len - (packet_data_ptr - packet_data_start_ptr);
 
     /* Loop all Options */
-    while (message_left && (*packet_data_ptr != 0xff)) {
+    uint_fast8_t option_byte;
+    while (message_left && ((option_byte = *packet_data_ptr) != 0xff)) {
         /* Get option length WITHOUT extensions */
-        uint16_t option_len = (*packet_data_ptr & 0x0F);
+        uint_fast16_t option_len = (option_byte & 0x0F);
         /* Get option number WITHOUT extensions */
-        uint16_t option_number = (*packet_data_ptr >> COAP_OPTIONS_OPTION_NUMBER_SHIFT);
+        uint_fast16_t option_number = (option_byte >> COAP_OPTIONS_OPTION_NUMBER_SHIFT);
 
         message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, packet_data_start_ptr, packet_len, 1);
-        int8_t    option_parse_result;
+        int_fast8_t    option_parse_result;
         /* Add possible option delta extension */
         option_parse_result = parse_ext_option(&option_number, &packet_data_ptr, packet_data_start_ptr, packet_len, &message_left);
         if (option_parse_result != 0) {
@@ -755,7 +756,7 @@ static const uint8_t * sn_coap_parser_options_parse(const uint8_t * restrict pac
  *
  * \return Return value is advanced input pointer. In failure case NULL is returned.
 */
-static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t * restrict packet_data_ptr, struct coap_s * restrict handle, uint16_t packet_left_len,  uint8_t ** restrict dst_pptr, uint16_t * restrict dst_len_ptr, sn_coap_option_numbers_e option, uint16_t option_number_len)
+static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_t * restrict packet_data_ptr, struct coap_s * restrict handle, uint_fast16_t packet_left_len,  uint8_t ** restrict dst_pptr, uint16_t * restrict dst_len_ptr, sn_coap_option_numbers_e option, uint_fast16_t option_number_len)
 {
 
     int           uri_query_needed_heap       = sn_coap_parser_options_count_needed_memory_multiple_option(packet_data_ptr, packet_left_len, option, option_number_len);
@@ -821,7 +822,7 @@ static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_
         message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, start_ptr, packet_left_len, 1);
 
         /* Add possible option length extension to resolve full length of the option */
-        int8_t option_parse_result = parse_ext_option(&option_number_len, &packet_data_ptr, start_ptr, packet_left_len, &message_left);
+        int_fast8_t option_parse_result = parse_ext_option(&option_number_len, &packet_data_ptr, start_ptr, packet_left_len, &message_left);
         if (option_parse_result != 0) {
             /* Extended option parsing failed. */
             return NULL;
@@ -846,7 +847,7 @@ static const uint8_t *sn_coap_parser_options_parse_multiple_options(const uint8_
  *
  * \param uint16_t option_number_len length of the first option part
  */
-static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t * restrict packet_data_ptr, uint16_t packet_left_len, sn_coap_option_numbers_e option, uint16_t option_number_len)
+static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint8_t * restrict packet_data_ptr, uint_fast16_t packet_left_len, sn_coap_option_numbers_e option, uint_fast16_t option_number_len)
 {
     int      ret_value              = 0;
     uint_fast16_t message_left      = packet_left_len;
@@ -874,7 +875,7 @@ static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint
         }
 
         /* Check if the value length is within buffer limits */
-        int8_t ptr_check_result = sn_coap_parser_check_packet_ptr(packet_data_ptr, start_ptr, packet_left_len, option_number_len);
+        int_fast8_t ptr_check_result = sn_coap_parser_check_packet_ptr(packet_data_ptr, start_ptr, packet_left_len, option_number_len);
         if (ptr_check_result != 0) {
             return -1;
         }
@@ -899,7 +900,7 @@ static int sn_coap_parser_options_count_needed_memory_multiple_option(const uint
         message_left = sn_coap_parser_move_packet_ptr(&packet_data_ptr, start_ptr, packet_left_len, 1);
 
         /* Add possible option length extension to resolve full length of the option */
-        int8_t option_parse_result = parse_ext_option(&option_number_len, &packet_data_ptr, start_ptr, packet_left_len, &message_left);
+        int_fast8_t option_parse_result = parse_ext_option(&option_number_len, &packet_data_ptr, start_ptr, packet_left_len, &message_left);
         if (option_parse_result != 0) {
             return -1;
         }

--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -52,8 +52,8 @@ static void                  sn_coap_protocol_linked_list_duplication_info_store
 static coap_duplication_info_s *sn_coap_protocol_linked_list_duplication_info_search(const struct coap_s *handle, const sn_nsdl_addr_s *scr_addr_ptr, const uint16_t msg_id);
 static void                  sn_coap_protocol_linked_list_duplication_info_remove_old_ones(struct coap_s *handle);
 static void                  sn_coap_protocol_duplication_info_free(struct coap_s *handle, coap_duplication_info_s *duplication_info_ptr);
-static bool                  sn_coap_protocol_update_duplicate_package_data(const struct coap_s *handle, const sn_nsdl_addr_s *dst_addr_ptr, const sn_coap_hdr_s *coap_msg_ptr, const int16_t data_size, const uint8_t *dst_packet_data_ptr);
-static bool                  sn_coap_protocol_update_duplicate_package_data_all(const struct coap_s *handle, const sn_nsdl_addr_s *dst_addr_ptr, const sn_coap_hdr_s *coap_msg_ptr, const int16_t data_size, const uint8_t *dst_packet_data_ptr);
+static bool                  sn_coap_protocol_update_duplicate_package_data(const struct coap_s *handle, const sn_nsdl_addr_s *dst_addr_ptr, const sn_coap_hdr_s *coap_msg_ptr, const int_fast16_t data_size, const uint8_t *dst_packet_data_ptr);
+static bool                  sn_coap_protocol_update_duplicate_package_data_all(const struct coap_s *handle, const sn_nsdl_addr_s *dst_addr_ptr, const sn_coap_hdr_s *coap_msg_ptr, const int_fast16_t data_size, const uint8_t *dst_packet_data_ptr);
 
 #endif
 
@@ -74,9 +74,9 @@ static int16_t                  store_blockwise_copy(struct coap_s *handle, cons
 #endif
 
 #if ENABLE_RESENDINGS
-static uint8_t               sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t send_packet_data_len, uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param);
+static uint8_t               sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint_fast16_t send_packet_data_len, uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param);
 static void                  sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, const sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
-static coap_send_msg_s      *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t packet_data_len);
+static coap_send_msg_s      *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint_fast16_t packet_data_len);
 static void                  sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handle, coap_send_msg_s *freed_send_msg_ptr);
 static uint_fast16_t         sn_coap_count_linked_list_size(const coap_send_msg_list_t *linked_list_ptr);
 static uint32_t              sn_coap_calculate_new_resend_time(const uint32_t current_time, const uint8_t interval, const uint8_t counter);
@@ -928,7 +928,7 @@ rescan:
  * \return 1 Msg stored properly
  *****************************************************************************/
 
-static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict dst_addr_ptr, uint16_t send_packet_data_len,
+static uint8_t sn_coap_protocol_linked_list_send_msg_store(struct coap_s * restrict handle, sn_nsdl_addr_s * restrict dst_addr_ptr, uint_fast16_t send_packet_data_len,
         uint8_t * restrict send_packet_data_ptr, uint32_t sending_time, void *param)
 {
 
@@ -1589,7 +1589,7 @@ rescan:
  * \return pointer to allocated struct
  *****************************************************************************/
 
-coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t packet_data_len)
+coap_send_msg_s *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint_fast16_t packet_data_len)
 {
 
     coap_send_msg_s *msg_ptr = sn_coap_protocol_calloc(handle, sizeof(coap_send_msg_s));
@@ -2443,7 +2443,7 @@ static sn_coap_hdr_s *sn_coap_protocol_copy_header(struct coap_s * restrict hand
 static bool sn_coap_protocol_update_duplicate_package_data(const struct coap_s *handle,
                                                            const sn_nsdl_addr_s *dst_addr_ptr,
                                                            const sn_coap_hdr_s *coap_msg_ptr,
-                                                           const int16_t data_size,
+                                                           const int_fast16_t data_size,
                                                            const uint8_t *dst_packet_data_ptr)
 {
     if (coap_msg_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT &&
@@ -2456,7 +2456,7 @@ static bool sn_coap_protocol_update_duplicate_package_data(const struct coap_s *
 static bool sn_coap_protocol_update_duplicate_package_data_all(const struct coap_s *handle,
                                                                const sn_nsdl_addr_s *dst_addr_ptr,
                                                                const sn_coap_hdr_s *coap_msg_ptr,
-                                                               const int16_t data_size,
+                                                               const int_fast16_t data_size,
                                                                const uint8_t *dst_packet_data_ptr)
 {
     coap_duplication_info_s* info = sn_coap_protocol_linked_list_duplication_info_search(handle,
@@ -2479,7 +2479,7 @@ static bool sn_coap_protocol_update_duplicate_package_data_all(const struct coap
 }
 #endif
 
-void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint16_t length)
+void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint_fast16_t length)
 {
     void *dest = handle->sn_coap_protocol_malloc(length);
 
@@ -2494,7 +2494,7 @@ void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, ui
  * are, but that would require the client to fill one up, as a wrapper filled from this
  * class would need access to the handle itself.
  */
-void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length)
+void *sn_coap_protocol_calloc(struct coap_s *handle, uint_fast16_t length)
 {
     void *result = handle->sn_coap_protocol_malloc(length);
 

--- a/test/mbed-coap/unittest/stubs/sn_coap_protocol_stub.c
+++ b/test/mbed-coap/unittest/stubs/sn_coap_protocol_stub.c
@@ -112,7 +112,7 @@ void sn_coap_protocol_block_remove(struct coap_s *handle, sn_nsdl_addr_s *source
 {
 }
 
-void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint16_t length)
+void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, uint_fast16_t length)
 {
     void *dest = handle->sn_coap_protocol_malloc(length);
 
@@ -127,7 +127,7 @@ void *sn_coap_protocol_malloc_copy(struct coap_s *handle, const void *source, ui
  * are, but that would require the client to fill one up, as a wrapper filled from this
  * class would need access to the handle itself.
  */
-void *sn_coap_protocol_calloc(struct coap_s *handle, uint16_t length)
+void *sn_coap_protocol_calloc(struct coap_s *handle, uint_fast16_t length)
 {
     void *result = handle->sn_coap_protocol_malloc(length);
 


### PR DESCRIPTION
<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[X] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[X] I confirm the moderators may change the PR before merging it in.

### Summary of changes <!-- Required -->

Three code size optimisations:

* Use fast rather than fixed types in CoAP internals
* Reorder structures for code size
* Don't use negative value on some minor internal static functions.

While investigating that, one undefined behaviour correction:

* Avoid unsafe pointer aliasing on write to `etag_len`.


