### PR TITLE
when sending next block request copy uri query options

### DIFF
--- a/source/sn_coap_protocol.c
+++ b/source/sn_coap_protocol.c
@@ -2060,6 +2060,16 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                         }
                         src_coap_blockwise_ack_msg_ptr->token_len = received_coap_msg_ptr->token_len;
                     }
+                    if (previous_blockwise_msg_ptr->coap_msg_ptr->options_list_ptr->uri_query_ptr) {
+
+                        src_coap_blockwise_ack_msg_ptr->options_list_ptr->uri_query_ptr = sn_coap_protocol_malloc_copy(handle, previous_blockwise_msg_ptr->coap_msg_ptr->options_list_ptr->uri_query_ptr, previous_blockwise_msg_ptr->coap_msg_ptr->options_list_ptr->uri_query_len);
+                        if (!src_coap_blockwise_ack_msg_ptr->options_list_ptr->uri_query_ptr) {
+                            sn_coap_parser_release_allocated_coap_msg_mem(handle, src_coap_blockwise_ack_msg_ptr);
+                            tr_error("sn_coap_handle_blockwise_message - failed to allocate for uri query ptr!");
+                            return NULL;
+                        }
+                        src_coap_blockwise_ack_msg_ptr->options_list_ptr->uri_query_len = previous_blockwise_msg_ptr->coap_msg_ptr->options_list_ptr->uri_query_len;
+                    }
 
                     sn_coap_protocol_linked_list_blockwise_msg_remove(handle, previous_blockwise_msg_ptr);
 


### PR DESCRIPTION
<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[] I confirm the moderators may change the PR before merging it in.

### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

Fixes missing uri query when doing a block transfer.

For example 

```coap://192.168.0.1/firmware?binary=mybinary.bin ```

will not work and the server will respond with resource not found.

After adding this blockwise transfer can continue working after block number 0.


